### PR TITLE
Adds `SecondaryNavigationLayout` and `BackNavigation` component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "editor.formatOnSave": true,
-  "eslint.codeActionsOnSave.rules": null
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.formatOnSave": true,
+  "eslint.codeActionsOnSave.rules": null
+}

--- a/app/Router.tsx
+++ b/app/Router.tsx
@@ -30,6 +30,8 @@ import { ServiceDiscoveryResults } from "pages/ServiceDiscoveryResults";
 import { LoginPage } from "pages/Auth/LoginPage";
 import { SignUpPage } from "pages/Auth/SignUpPage";
 import { LogoutPage } from "pages/Auth/LogoutPage";
+import { SecondaryNavigationLayout } from "components/layouts/SecondaryNavigationLayout";
+import { BackNavigation } from "components/layouts/BackNavigation";
 
 const { homePageComponent } = whiteLabel;
 
@@ -46,6 +48,7 @@ export const Router = ({
   setPopUpMessage: (msg: PopupMessageProp) => void;
 }) => {
   const { authState } = useAppContext();
+
 
   return (
     <Switch>
@@ -65,7 +68,11 @@ export const Router = ({
       <Route
         exact
         path="/organizations/:id"
-        component={OrganizationListingPage}
+        component={() =>
+          <SecondaryNavigationLayout navigationChildren={<BackNavigation defaultReturnTo="/search" />}>
+              <OrganizationListingPage />
+          </SecondaryNavigationLayout>
+        }
       />
       <Route
         exact

--- a/app/Router.tsx
+++ b/app/Router.tsx
@@ -69,8 +69,11 @@ export const Router = ({
         exact
         path="/organizations/:id"
         component={() =>
-          <SecondaryNavigationLayout navigationChildren={<BackNavigation defaultReturnTo="/search" />}>
-              <OrganizationListingPage />
+          <SecondaryNavigationLayout
+            navigationChildren={
+              <BackNavigation defaultReturnTo="/search" />
+            }>
+            <OrganizationListingPage />
           </SecondaryNavigationLayout>
         }
       />

--- a/app/Router.tsx
+++ b/app/Router.tsx
@@ -49,7 +49,6 @@ export const Router = ({
 }) => {
   const { authState } = useAppContext();
 
-
   return (
     <Switch>
       <Route exact path="/" component={homePage} />
@@ -68,14 +67,13 @@ export const Router = ({
       <Route
         exact
         path="/organizations/:id"
-        component={() =>
+        component={() => (
           <SecondaryNavigationLayout
-            navigationChildren={
-              <BackNavigation defaultReturnTo="/search" />
-            }>
+            navigationChildren={<BackNavigation defaultReturnTo="/search" />}
+          >
             <OrganizationListingPage />
           </SecondaryNavigationLayout>
-        }
+        )}
       />
       <Route
         exact

--- a/app/components/layouts/BackNavigation.tsx
+++ b/app/components/layouts/BackNavigation.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { Button } from 'components/ui/inline/Button/Button';
+import { useHistory } from 'react-router-dom';
+
+// Renders a smart back link that handles pages visited directly or from referring page
+export const BackNavigation = ({
+  defaultReturnTo
+}: {
+  defaultReturnTo: string;
+}) => {
+  const history = useHistory();
+
+  // The "POP" action is reserved as a default action for newly created history objects. `react-router-dom` depends on
+  // another history library that defines this behavior. Read more:
+  // https://github.com/remix-run/history/blob/main/docs/api-reference.md#reference
+  const backDestination = history.action === "POP"
+    ? () => history.push(defaultReturnTo)
+    : () => history.goBack()
+
+  return (
+      <Button onClick={backDestination} variant="linkWhite" >
+        Back to Service Listings
+      </Button>
+  )
+}

--- a/app/components/layouts/BackNavigation.tsx
+++ b/app/components/layouts/BackNavigation.tsx
@@ -20,7 +20,7 @@ export const BackNavigation = ({
       : () => history.goBack();
 
   return (
-    <Button onClick={backDestination} variant="linkWhite">
+    <Button onClick={backDestination} variant="linkWhite" arrowVariant="before">
       Back to Service Listings
     </Button>
   );

--- a/app/components/layouts/BackNavigation.tsx
+++ b/app/components/layouts/BackNavigation.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
-import { Button } from 'components/ui/inline/Button/Button';
-import { useHistory } from 'react-router-dom';
+import { Button } from "components/ui/inline/Button/Button";
+import { useHistory } from "react-router-dom";
 
 // Renders a smart back link that handles pages visited directly or from referring page
 export const BackNavigation = ({
-  defaultReturnTo
+  defaultReturnTo,
 }: {
   defaultReturnTo: string;
 }) => {
@@ -14,13 +14,14 @@ export const BackNavigation = ({
   // The "POP" action is reserved as a default action for newly created history objects. `react-router-dom` depends on
   // another history library that defines this behavior. Read more:
   // https://github.com/remix-run/history/blob/main/docs/api-reference.md#reference
-  const backDestination = history.action === "POP"
-    ? () => history.push(defaultReturnTo)
-    : () => history.goBack()
+  const backDestination =
+    history.action === "POP"
+      ? () => history.push(defaultReturnTo)
+      : () => history.goBack();
 
   return (
-      <Button onClick={backDestination} variant="linkWhite" >
-        Back to Service Listings
-      </Button>
-  )
-}
+    <Button onClick={backDestination} variant="linkWhite">
+      Back to Service Listings
+    </Button>
+  );
+};

--- a/app/components/layouts/SecondaryNavigation.module.scss
+++ b/app/components/layouts/SecondaryNavigation.module.scss
@@ -2,6 +2,15 @@
 
 .container {
   background: $surface-4;
-  padding: $spacing-6 $spacing-16;
+  padding: $spacing-6 $spacing-8;
   color: $text-tertiary;
+
+  @media screen and (max-width: $break-tablet-s) {
+    padding: $spacing-6 calc-em(20px);
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+    }
+  }
 }

--- a/app/components/layouts/SecondaryNavigation.module.scss
+++ b/app/components/layouts/SecondaryNavigation.module.scss
@@ -1,0 +1,7 @@
+@import "app/styles/utils/_helpers.scss";
+
+.container {
+  background: $surface-4;
+  padding: $spacing-6 $spacing-16;
+  color: $text-tertiary;
+}

--- a/app/components/layouts/SecondaryNavigationLayout.tsx
+++ b/app/components/layouts/SecondaryNavigationLayout.tsx
@@ -1,0 +1,22 @@
+import React, { ReactNode } from "react";
+
+import styles from "./SecondaryNavigation.module.scss";
+
+// TODO
+export const SecondaryNavigationLayout = ({
+  children,
+  navigationChildren,
+}: {
+  children: ReactNode;
+  navigationChildren: ReactNode;
+}) => {
+
+  return (
+    <>
+      <div className={`${styles.container}`}>
+      {navigationChildren}
+      </div>
+      {children}
+    </>
+  )
+}

--- a/app/components/layouts/SecondaryNavigationLayout.tsx
+++ b/app/components/layouts/SecondaryNavigationLayout.tsx
@@ -9,15 +9,12 @@ export const SecondaryNavigationLayout = ({
   navigationChildren,
 }: {
   children: ReactNode;
-  navigationChildren: ReactNode[];
+  navigationChildren: ReactNode | ReactNode[];
 }) => {
-
   return (
     <>
-      <div className={`${styles.container}`}>
-        {navigationChildren}
-      </div>
+      <div className={`${styles.container}`}>{navigationChildren}</div>
       {children}
     </>
-  )
-}
+  );
+};

--- a/app/components/layouts/SecondaryNavigationLayout.tsx
+++ b/app/components/layouts/SecondaryNavigationLayout.tsx
@@ -2,19 +2,20 @@ import React, { ReactNode } from "react";
 
 import styles from "./SecondaryNavigation.module.scss";
 
-// TODO
+// Wrap base page components in Router to add a secondary navigation bar that accepts
+// an argument for rendering out a component of navigation items.
 export const SecondaryNavigationLayout = ({
   children,
   navigationChildren,
 }: {
   children: ReactNode;
-  navigationChildren: ReactNode;
+  navigationChildren: ReactNode[];
 }) => {
 
   return (
     <>
       <div className={`${styles.container}`}>
-      {navigationChildren}
+        {navigationChildren}
       </div>
       {children}
     </>


### PR DESCRIPTION
## Issue Overview

See Notion: https://www.notion.so/exygy/Back-Navigation-Bar-2564a5fd669e46f79eeba5ec61ff3c47

## Description

- [x] Adds an _elective_ layout component wrapper for page components that want to include a `SecondaryNavigation`. It's possible this could be added as a global wrapper under `Navigation` in `App.tsx` but I wanted to observe in practice first how extensively we might use it. 
- [x] This layout component parameterizes the child navigation items via a prop, thereby separating presentation and behavior components
- [x] Adds a `BackNavigation` component that leverages `react-router-dom`'s `useHistory` to go back and also smartly route to a custom page if entered directly

Demo with entry from incognito and then referring page:

https://github.com/Exygy/askdarcel-web/assets/5185/a9bfda17-0fae-4201-b8b0-c3408406d5b2

## How Can This Be Tested/Reviewed?

Run the app locally and visit http://localhost:8080/organizations/60

<details>
<summary>Reviewer Notes:</summary>

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go
</details>