### PR TITLE
Long description fixes

### DIFF
--- a/app/components/listing/ServiceDetails.tsx
+++ b/app/components/listing/ServiceDetails.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Link } from "react-router-dom";
+import { removeAsterisksAndHashes } from "utils/strings";
 import { Notes } from "./Notes";
 import { Service, RecurringSchedule } from "../../models";
 
@@ -27,7 +28,7 @@ export const ServiceDetails = ({ service }: { service: Service }) => {
       </h2>
       <ReactMarkdown
         className="rendered-markdown service--description"
-        source={service.long_description}
+        source={removeAsterisksAndHashes(service.long_description)}
       />
       <div
         className="service--details-toggle"

--- a/app/components/search/SearchResults/SearchResults.module.scss
+++ b/app/components/search/SearchResults/SearchResults.module.scss
@@ -112,7 +112,7 @@
 }
 
 .address {
-  font-size: 14px;
+  font-size: 16px;
   margin-top: $general-spacing-s;
   color: $text-secondary;
 
@@ -124,7 +124,7 @@
   }
 
   @media screen and (max-width: $break-tablet-s) {
-    font-size: 16px;
+    font-size: 14px;
   }
 }
 
@@ -245,6 +245,10 @@
     display: block;
     padding: 20px 0;
     border-left: 0;
+
+    li {
+      font-size: 16px;
+    }
   }
 
   .sideLink {

--- a/app/components/search/SearchResults/SearchResults.tsx
+++ b/app/components/search/SearchResults/SearchResults.tsx
@@ -178,6 +178,7 @@ const SearchResult = ({
             <div className={`notranslate ${styles.address}`}>
               {renderAddressMetadata(hit)}
             </div>
+            {/* Once we can update all dependencies, we can add remarkBreaks as remarkPlugin here */}
             <ReactMarkdown
               className={`rendered-markdown ${styles.description}`}
               source={

--- a/app/pages/ServiceListingPage/ServiceListingPage.tsx
+++ b/app/pages/ServiceListingPage/ServiceListingPage.tsx
@@ -174,7 +174,15 @@ export const ServiceListingPage = () => {
                 {resource.services
                   .filter((srv) => srv.id !== service.id)
                   .map((srv) => (
-                    <ServiceCard service={srv} key={srv.id} />
+                    <ServiceCard
+                      service={{
+                        ...srv,
+                        long_description: removeAsterisksAndHashes(
+                          srv.long_description
+                        ),
+                      }}
+                      key={srv.id}
+                    />
                   ))}
               </ServiceListingSection>
             )}

--- a/app/styles/utils/_helpers.scss
+++ b/app/styles/utils/_helpers.scss
@@ -150,10 +150,10 @@ small {
 }
 
 a {
-  color: $color-brand;
+  color: $text-link;
   cursor: pointer;
   &:hover {
-    color: $color-brand-dark;
+    color: $text-link-hover;
     text-decoration: underline;
   }
   @include transition(all 0.2s);

--- a/app/utils/strings.spec.ts
+++ b/app/utils/strings.spec.ts
@@ -1,0 +1,12 @@
+import { expect } from "chai";
+import { removeAsterisksAndHashes } from "./strings";
+
+describe("removeAsterisksAndHashes", () => {
+  it("removes # and *", () => {
+    const str = `# **Service Contact Information:**\n# **Another Heading:**`;
+
+    const actual = removeAsterisksAndHashes(str);
+    const expected = ` Service Contact Information:\n Another Heading:`;
+    expect(actual).to.equal(expected);
+  });
+});

--- a/app/utils/strings.ts
+++ b/app/utils/strings.ts
@@ -6,5 +6,5 @@
  */
 export function removeAsterisksAndHashes(input: string): string {
   // Remove all asterisks and hash symbols
-  return input.replace(/[#]/g, "");
+  return input.replace(/[*#]/g, "");
 }


### PR DESCRIPTION
This adds some changes missed by https://github.com/Exygy/askdarcel-web/pull/48, and a fix and a test for removeAsterisksAndHashes(). 

- removeAsterisksAndHashes() fix - add * to function (was only removing # )
- removeAsterisksAndHashes() test - takes in string with * and # and returns a string with out (this strips unwanted headers that cause a11y problems)
- formats the long-descriptions in the service listing page components 