### PR TITLE
[OUR415-87] Decouples `<SiteSearch />` from `<Navigation />`

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -99,7 +99,6 @@ export const App = () => {
         </span>
         <div id={pageWrapId}>
           <Navigation
-            showSearch={showSearch}
             toggleHamburgerMenu={() => setHamburgerOpen(!hamburgerOpen)}
           />
           {showBanner && <Banner />}

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -26,8 +26,7 @@ import MetaImage from "./assets/img/sfsg-preview.png";
 
 import styles from "./App.module.scss";
 
-const { intercom, showBanner, showSearch, siteUrl, title, userWay } =
-  whiteLabel;
+const { intercom, showBanner, siteUrl, title, userWay } = whiteLabel;
 const outerContainerId = "outer-container";
 const pageWrapId = "page-wrap";
 

--- a/app/components/ui/Navigation.tsx
+++ b/app/components/ui/Navigation.tsx
@@ -1,195 +1,46 @@
-import React, { FormEvent, useState } from "react";
-import { Link, useHistory } from "react-router-dom";
-import cn from "classnames";
-import qs from "qs";
-import { useAppContext, whiteLabel } from "utils";
+import React from "react";
+import { Link } from "react-router-dom";
 import Translate from "./Translate";
 import styles from "./Navigation.module.scss";
 
-const {
-  appImages: { logoSmall },
-  logoLinkDestination,
-  navLogoStyle,
-  showMobileNav,
-  showReportCrisis,
-  siteNavStyle,
-  title,
-} = whiteLabel;
-
 export const Navigation = ({
-  showSearch,
   toggleHamburgerMenu,
 }: {
-  showSearch: boolean;
   toggleHamburgerMenu: () => void;
 }) => {
-  const [query, setQuery] = useState("");
-  const [showSecondarySearch, setShowSecondarySearch] = useState(false);
-  const searchProps = { query, setQuery };
-
-  // On the SF Families whitelabel site, we want to link to an external site
-  // (the SF Families website), so it must be an external link. For other
-  // sites, we want to just use an internal react-router Link to the root URL,
-  // since 1) this allows us to use react-router routing and 2) this avoids
-  // having staging and development environments link to the production site.
   return (
-    <nav className={siteNavStyle}>
+    <nav className={styles.siteNav}>
       <div className={styles.primaryRow}>
         <div className={styles.navLeft}>
           <SiteLogo />
-          {showSearch && (
-            <SiteSearch extraClasses={styles.navSearchFull} {...searchProps} />
-          )}
         </div>
         <SiteLinks />
-
-        {showMobileNav && (
-          <div className={styles.mobileNavigation}>
-            <button
-              type="button"
-              aria-label="search for a service"
-              className={styles.searchButton}
-              onClick={() => setShowSecondarySearch(!showSecondarySearch)}
-            />
-            <button
-              type="button"
-              aria-label="navigation menu"
-              className={styles.hamburgerButton}
-              onClick={toggleHamburgerMenu}
-            />
-          </div>
-        )}
-      </div>
-
-      {showSecondarySearch && (
-        <div className={styles.secondaryRowWrapper}>
-          <div className={styles.secondaryRow}>
-            <SiteSearch
-              extraClasses={styles.mobileNavigation}
-              {...searchProps}
-            />
-          </div>
+        <div className={styles.mobileNavigation}>
+          <button
+            type="button"
+            aria-label="navigation menu"
+            className={styles.hamburgerButton}
+            onClick={toggleHamburgerMenu}
+          />
         </div>
-      )}
+      </div>
     </nav>
   );
 };
 
-const SiteLogo = () =>
-  /^https?:\/\//.test(logoLinkDestination) ? (
-    <a
-      className={`${navLogoStyle} ${styles.navLogo}`}
-      href={logoLinkDestination}
-    >
-      <img src={logoSmall} alt={title} />
-    </a>
-  ) : (
-    <Link className={`${navLogoStyle} ${styles.navLogo}`} to="/">
-      <img src={logoSmall} alt={title} />
-    </Link>
-  );
+const SiteLogo = () => (
+  <Link className={`${styles.navLogo}`} to="/">
+    {/* TODO */}
+    [SITE LOGO HERE]
+  </Link>
+);
 
 const SiteLinks = () => {
-  const { authState } = useAppContext();
-
   return (
     <ul className={styles.navRight}>
-      {/* Todo: This will eventually be replaced by a user icon with a dropdown menu of account related options.
-          The designs are still forthcoming. For now, it serves as a basic log-out functionality for the purposes
-          of development and testing.
-      */}
-      {authState && (
-        <li>
-          <Link to="/log-out">Log Out</Link>
-        </li>
-      )}
-      <li>
-        <Link to="/about">About</Link>
-      </li>
-      <li>
-        <a
-          href="https://help.sfserviceguide.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          FAQ
-        </a>
-      </li>
-      <li>
-        <a
-          href="https://help.sfserviceguide.org/en/collections/1719243-contact-us"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Contact Us
-        </a>
-      </li>
-      {showReportCrisis && (
-        <li>
-          <a
-            type="button"
-            aria-label="report street crisis"
-            href="https://sf.gov/information/reporting-concerns-about-street-crises-and-conditions"
-            className={styles.buttonLink}
-            target="blank"
-            rel="noopener noreferrer"
-          >
-            Report Street Crisis
-          </a>
-        </li>
-      )}
       <Translate />
     </ul>
   );
 };
 
-const SiteSearch = ({
-  query,
-  setQuery,
-  extraClasses,
-}: {
-  extraClasses?: string;
-  query: string;
-  setQuery: (q: string) => void;
-}) => {
-  const history = useHistory();
-
-  const submitSearch = (e: FormEvent) => {
-    e.preventDefault();
-    const searchState = qs.parse(window.location.search.slice(1));
-
-    if (query) {
-      searchState.query = query;
-    } else {
-      delete searchState.query;
-    }
-
-    history.push(`/search?${qs.stringify(searchState)}`);
-    return false;
-  };
-
-  return (
-    <form
-      onSubmit={submitSearch}
-      className={cn([
-        styles.navSearch,
-        extraClasses,
-        "search-container",
-        "form-row",
-      ])}
-      role="search"
-    >
-      <input
-        onChange={(e) => setQuery(e.target.value)}
-        value={query}
-        type="text"
-        className={styles.searchField}
-        placeholder="Search for a service or organization"
-        name="srch-term"
-        id="srch-term"
-      />
-    </form>
-  );
-};
-
-export default SiteSearch;
+export default Navigation;

--- a/app/components/ui/Navigation.tsx
+++ b/app/components/ui/Navigation.tsx
@@ -37,9 +37,9 @@ const SiteLogo = () => (
 
 const SiteLinks = () => {
   return (
-    <ul className={styles.navRight}>
+    <div className={styles.navRight}>
       <Translate />
-    </ul>
+    </div>
   );
 };
 

--- a/app/components/ui/SiteSearch.module.scss
+++ b/app/components/ui/SiteSearch.module.scss
@@ -1,0 +1,24 @@
+@import "../../styles/utils/_helpers.scss";
+
+.navSearch {
+  display: inline-block;
+
+  .searchField {
+    $font-size: calc-em(15px);
+    background-repeat: no-repeat;
+    background-image: url(../../assets/img/ic-search.png);
+    background-size: 18px 18px;
+    background-position: calc-em(15px) center;
+    font-size: $font-size;
+    padding-left: calc-em(45px);
+    width: calc-em(400px);
+    height: calc-em(40px);
+    border: 0;
+    background-color: $color-grey1;
+
+    &::placeholder {
+      font-size: $font-size;
+      font-style: normal;
+    }
+  }
+}

--- a/app/components/ui/SiteSearch.tsx
+++ b/app/components/ui/SiteSearch.tsx
@@ -1,0 +1,50 @@
+import React, { FormEvent, useState } from "react";
+import { useHistory } from "react-router-dom";
+import cn from "classnames";
+import qs from "qs";
+import styles from "./SiteSearch.module.scss";
+
+// TODO: Previously used as a global search in SF Service Guide. Can be repurposed for Our415 as a Top Level Category
+// search per designs or similar. See:
+// https://www.figma.com/proto/iDBeNK7SnZXF8wc3pbPTCY/Our415-Site?node-id=2629-11357&t=q9JDI7LISYb2Ok6T-1
+export const SiteSearch = ({ extraClasses }: { extraClasses?: string }) => {
+  const [query, setQuery] = useState("");
+  const history = useHistory();
+
+  const submitSearch = (e: FormEvent) => {
+    e.preventDefault();
+    const searchState = qs.parse(window.location.search.slice(1));
+
+    if (query) {
+      searchState.query = query;
+    } else {
+      delete searchState.query;
+    }
+
+    history.push(`/search?${qs.stringify(searchState)}`);
+    return false;
+  };
+
+  return (
+    <form
+      onSubmit={submitSearch}
+      className={cn([
+        styles.navSearch,
+        extraClasses,
+        "search-container",
+        "form-row",
+      ])}
+      role="search"
+    >
+      <input
+        onChange={(e) => setQuery(e.target.value)}
+        value={query}
+        type="text"
+        className={styles.searchField}
+        placeholder="Search for a service or organization"
+        name="srch-term"
+        id="srch-term"
+      />
+    </form>
+  );
+};


### PR DESCRIPTION
This is part of N to implement the new site navigation. These changes add some needed separation and refinement of the header components. Just moving code around and setting up placeholders for new components.

Additionally:
- [x] Removes _whitelabel_ parameters from these components
- [x] Removes static links

Screenshot: 
![image](https://github.com/Exygy/askdarcel-web/assets/5185/32c8679f-1a0b-4a4e-bea8-7f0a2125ab69)
