### PR TITLE
Separates api response types from model types

### DIFF
--- a/app/components/ui/Footer/Footer.tsx
+++ b/app/components/ui/Footer/Footer.tsx
@@ -4,7 +4,7 @@ import { htmlWithBreaks } from "utils/sanity";
 import Our415Logo from "assets/img/our415-white.png";
 import SFSeal from "assets/img/sf-seal-white.png";
 import DCYFLogo from "assets/img/dcyf-white.png";
-import { DynamicLink } from "models/Strapi";
+import { StrapiModel } from "models/Strapi";
 import { FooterColumn } from "./FooterColumn";
 import { useFooterData } from "../../../hooks/StrapiAPI";
 
@@ -51,7 +51,7 @@ export const Footer = () => {
 
           <div className="site-footer__links">
             {!error &&
-              data?.links.map((item: DynamicLink) => (
+              data?.links.map((item: StrapiModel.DynamicLink) => (
                 <FooterColumn key={item.id} column={item} />
               ))}
           </div>

--- a/app/components/ui/Footer/FooterColumn.tsx
+++ b/app/components/ui/Footer/FooterColumn.tsx
@@ -1,8 +1,12 @@
 import React from "react";
-import { DynamicLink } from "models/Strapi";
+import { StrapiModel } from "models/Strapi";
 import { FooterLink } from "./FooterLink";
 
-export const FooterColumn = ({ column }: { column: DynamicLink }) => {
+export const FooterColumn = ({
+  column,
+}: {
+  column: StrapiModel.DynamicLink;
+}) => {
   return (
     <figure>
       <figcaption>{column.title}</figcaption>

--- a/app/components/ui/Footer/FooterLink.tsx
+++ b/app/components/ui/Footer/FooterLink.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { type Link as FooterLinkType } from "../../../models/Strapi";
+import { StrapiModel } from "models/Strapi";
 
-export const FooterLink = ({ link }: { link: FooterLinkType }) => {
+export const FooterLink = ({ link }: { link: StrapiModel.Link }) => {
   const isInternalLink = (url: string): boolean => {
     return url.startsWith("/") || url.startsWith(window.location.origin);
   };

--- a/app/hooks/StrapiAPI.ts
+++ b/app/hooks/StrapiAPI.ts
@@ -104,9 +104,9 @@ export namespace StrapiApi {
 
   export interface NavigationMenuResponse {
     id: number;
-    // The plurality mismatch here is a quirk of strapi's serialization of repeatable nested components
     __component: "navigation.menu";
-    link: Link[];
+    // The plurality mismatch here is a quirk of strapi's serialization of repeatable nested components
+    link: LinkResponse[];
     title: string;
   }
 }

--- a/app/hooks/StrapiAPI.ts
+++ b/app/hooks/StrapiAPI.ts
@@ -116,7 +116,7 @@ export interface FormatsResponse {
     provider: string;
     createdAt: string;
     updatedAt: string;
-
+  formats: FormatsResponse
     // TODO uknown types
     // provider_metadata: null;
     // formats: null;

--- a/app/hooks/StrapiAPI.ts
+++ b/app/hooks/StrapiAPI.ts
@@ -81,6 +81,26 @@ export namespace StrapiApi {
     navigation: NavigationMenuResponse[];
   };
 
+export interface ImageFormatResponse {
+  ext: string;
+  url: string;
+  hash: string;
+  mime: string;
+  name: string;
+  path?: string;
+  size: number;
+  width: number;
+  height: number;
+  sizeInBytes: number;
+}
+
+export interface FormatsResponse {
+  large: ImageFormatResponse;
+  medium: ImageFormatResponse;
+  small: ImageFormatResponse;
+  thumbnail: ImageFormatResponse;
+}
+
   export interface LogoResponse {
     name: string;
     alternativeText: string;

--- a/app/hooks/StrapiAPI.ts
+++ b/app/hooks/StrapiAPI.ts
@@ -81,25 +81,25 @@ export namespace StrapiApi {
     navigation: NavigationMenuResponse[];
   };
 
-export interface ImageFormatResponse {
-  ext: string;
-  url: string;
-  hash: string;
-  mime: string;
-  name: string;
-  path?: string;
-  size: number;
-  width: number;
-  height: number;
-  sizeInBytes: number;
-}
+  export interface ImageFormatResponse {
+    ext: string;
+    url: string;
+    hash: string;
+    mime: string;
+    name: string;
+    path?: string;
+    size: number;
+    width: number;
+    height: number;
+    sizeInBytes: number;
+  }
 
-export interface FormatsResponse {
-  large: ImageFormatResponse;
-  medium: ImageFormatResponse;
-  small: ImageFormatResponse;
-  thumbnail: ImageFormatResponse;
-}
+  export interface FormatsResponse {
+    large: ImageFormatResponse;
+    medium: ImageFormatResponse;
+    small: ImageFormatResponse;
+    thumbnail: ImageFormatResponse;
+  }
 
   export interface LogoResponse {
     name: string;
@@ -116,7 +116,7 @@ export interface FormatsResponse {
     provider: string;
     createdAt: string;
     updatedAt: string;
-  formats: FormatsResponse
+    formats: FormatsResponse
     // TODO uknown types
     // provider_metadata: null;
     // formats: null;

--- a/app/hooks/StrapiAPI.ts
+++ b/app/hooks/StrapiAPI.ts
@@ -1,6 +1,14 @@
+/**
+  NOTE @rosschapman: Developers may be tempted to auto-generate response types as described in the strapi docs using cli
+  commands from the `@strapi/strapi` module, but I've noticed the output is funky for use in a client application in its
+  raw form. For example, string fields from the recommended module are typed as `Attribute.String` but this type isn't compatible
+  with `string` 🤦. Strapi offers this cumbersome approach to sync types, but also caveats this is not an official
+  solution: https://strapi.io/blog/improve-your-frontend-experience-with-strapi-types-and-type-script. Even so, I still
+  don't trust the generated types in view of the above example.
+*/
+
 import useSWR from "swr";
 import fetcher from "utils/fetcher";
-import { type Footer, type StrapiResponse } from "models/Strapi";
 import config from "../config";
 
 interface SWRHookResult<T> {
@@ -8,18 +16,15 @@ interface SWRHookResult<T> {
   error?: Error;
   isLoading: boolean;
 }
-
 function useStrapiHook<T>(path: string): SWRHookResult<T> {
   const dataFetcher = () =>
-    fetcher<StrapiResponse<T>>(`${config.STRAPI_API_URL}/api/${path}`, {
+    fetcher<StrapiApi.BaseResponse<T>>(`${config.STRAPI_API_URL}/api/${path}`, {
       Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
     });
-
-  const { data, error, isLoading } = useSWR<StrapiResponse<T>>(
+  const { data, error, isLoading } = useSWR<StrapiApi.BaseResponse<T>>(
     `/api/${path}`,
     dataFetcher
   );
-
   return {
     data: data?.data ? data.data.attributes : null,
     error,
@@ -28,5 +33,80 @@ function useStrapiHook<T>(path: string): SWRHookResult<T> {
 }
 
 export function useFooterData() {
-  return useStrapiHook<Footer>("footer?populate[links][populate]=*");
+  return useStrapiHook<StrapiApi.FooterResponse>("footer?populate[links][populate]=*");
+}
+
+export function useNavigationData() {
+  return useStrapiHook<StrapiApi.HeaderResponse>("header?populate[logo]=*&populate[navigation][populate]=*");
+}
+
+export namespace StrapiApi {
+  export interface BaseResponse<T> {
+    data: {
+      id: number;
+      attributes: T;
+      meta: {
+        [key: string]: string;
+      };
+    } | null;
+  }
+  export interface LinkResponse {
+    id: number;
+    url: string;
+    text: string;
+  }
+
+  export interface DynamicLinkResponse {
+    id: number;
+    // __component is a key used by Strapi
+    // that may not have practical purposes for the frontend
+    __component: string;
+    title: string;
+    link: LinkResponse[];
+  }
+
+  export interface FooterResponse {
+    address: string;
+    email_address: string;
+    phone_number: string;
+    links: DynamicLinkResponse[];
+  }
+
+  export interface HeaderResponse {
+    logo: {
+      data: {
+        attributes: LogoResponse;
+      };
+    };
+    navigation: NavigationMenuResponse[];
+  };
+
+  export interface LogoResponse {
+    name: string;
+    alternativeText: string;
+    caption: string;
+    width: number;
+    height: number;
+    hash: string;
+    ext: string;
+    mime: string;
+    size: number;
+    url: string;
+    previewUrl: string;
+    provider: string;
+    createdAt: string;
+    updatedAt: string;
+
+    // TODO uknown types
+    // provider_metadata: null;
+    // formats: null;
+  }
+
+  export interface NavigationMenuResponse {
+    id: number;
+    // The plurality mismatch here is a quirk of strapi's serialization of repeatable nested components
+    __component: "navigation.menu";
+    link: Link[];
+    title: string;
+  }
 }

--- a/app/models/Strapi.ts
+++ b/app/models/Strapi.ts
@@ -1,31 +1,14 @@
-export interface StrapiResponse<T> {
-  data: {
-    id: number;
-    attributes: T;
-    meta: {
-      [key: string]: string;
-    };
-  } | null;
-}
+import { StrapiApi } from 'hooks/StrapiAPI';
 
-export interface Link {
-  id: number;
-  url: string;
-  text: string;
-}
-
-export interface DynamicLink {
-  id: number;
-  // __component is a key used by Strapi
-  // that may not have practical purposes for the frontend
-  __component: string;
-  title: string;
-  link: Link[];
-}
-
-export interface Footer {
-  address: string;
-  email_address: string;
-  phone_number: string;
-  links: DynamicLink[];
+/**
+  Model interfaces are a subtype of Strapi api responses that only include properties needed by consuming components
+*/
+export namespace StrapiModel {
+  export interface Link extends StrapiApi.Link { }
+  export interface DynamicLink extends Omit<StrapiApi.DynamicLinkResponse, "__component"> { }
+  export interface Footer extends StrapiApi.FooterResponse { }
+  export interface Header extends StrapiApi.HeaderResponse { }
+  export interface Logo extends Pick<StrapiApi.Logo, "width" | "height" | "alternativeText" | "url"> { }
+  export interface NavigationMenu extends StrapiApi.NavigationMenuResponse {
+  }
 }

--- a/app/models/Strapi.ts
+++ b/app/models/Strapi.ts
@@ -4,11 +4,11 @@ import { StrapiApi } from 'hooks/StrapiAPI';
   Model interfaces are a subtype of Strapi api responses that only include properties needed by consuming components
 */
 export namespace StrapiModel {
-  export interface Link extends StrapiApi.Link { }
+  export interface Link extends StrapiApi.LinkResponse { }
   export interface DynamicLink extends Omit<StrapiApi.DynamicLinkResponse, "__component"> { }
   export interface Footer extends StrapiApi.FooterResponse { }
   export interface Header extends StrapiApi.HeaderResponse { }
-  export interface Logo extends Pick<StrapiApi.Logo, "width" | "height" | "alternativeText" | "url"> { }
+  export interface Logo extends Pick<StrapiApi.LogoResponse, "width" | "height" | "alternativeText" | "url"> { }
   export interface NavigationMenu extends StrapiApi.NavigationMenuResponse {
   }
 }


### PR DESCRIPTION
The idea here is to create a stronger boundary between the api adapter layer and the domain object data consumed by components. It's a little bit more overhead at the start, but IME this creates a valuable clarity for devs to know when they are working with transformed or raw data objects. 

Additionally: 
- [x] Adds `StrapiApi` and `StrapiModel` namespaces to avoid conflicts with components. Eg: `Footer` and `StrapiModel.Footer`.