### PR TITLE
Mobile category cards are left aligned

### DIFF
--- a/app/components/search/Sidebar/MapToggleButtons.tsx
+++ b/app/components/search/Sidebar/MapToggleButtons.tsx
@@ -19,6 +19,7 @@ const MapToggleButtons = ({
           "no-transition"
         )}
         onClick={() => setCollapseMap(false)}
+        aria-label="Expand map"
       >
         <span className={!collapseMap ? styles.activeView : ""}>
           <i className="fa-solid fa-map" />
@@ -32,6 +33,7 @@ const MapToggleButtons = ({
           "no-transition"
         )}
         onClick={() => setCollapseMap(true)}
+        aria-label="Collapse map"
       >
         <span className={collapseMap ? styles.activeView : ""}>
           <i className="fa-solid fa-list" />

--- a/app/components/ui/Cards/CategoryCard.module.scss
+++ b/app/components/ui/Cards/CategoryCard.module.scss
@@ -20,6 +20,10 @@
     height: 150px;
   }
 
+  @media screen and (max-width: $break-tablet-p) {
+    justify-content: start;
+  }
+
   &:hover {
     color: $color-brand-dark;
     text-decoration: none;

--- a/app/components/ui/MapElements.tsx
+++ b/app/components/ui/MapElements.tsx
@@ -33,12 +33,7 @@ export const CustomMarker = ({
 }) => (
   <svg width="36" height="50" viewBox="0 0 110 85" className="marker">
     <g fill="none" fillRule="evenodd">
-      <g
-        transform="translate(-58, 0)"
-        stroke="#000"
-        id="pin"
-        viewBox="0 0 100 100"
-      >
+      <g transform="translate(-58, 0)" stroke="#000" id="pin">
         <path
           d="M160.39 34.315c0 18.546-36.825 83.958-36.825 83.958S86.74 52.86 86.74 34.315C86.74 15.768 104.885.73 123.565.73c18.68 0 36.825 15.038 36.825 33.585z"
           strokeWidth="3"


### PR DESCRIPTION
Quick PR per https://www.notion.so/exygy/Text-Center-Aligned-Instead-of-Left-Aligned-on-Mobile-in-Browse-Service-fb693e28b92b4d90afa514201cd6fa3b

Makes it so the category cards in the Browse Services section are left aligned on mobile