### PR TITLE
Fix back button bug

### DIFF
--- a/app/components/ui/SiteSearchInput.tsx
+++ b/app/components/ui/SiteSearchInput.tsx
@@ -25,6 +25,7 @@ export const SiteSearchInput = () => {
 
     if (query) {
       searchState.query = query;
+      searchState.page = "1";
     } else {
       delete searchState.query;
     }

--- a/app/pages/SearchResultsPage/SearchResultsPage.tsx
+++ b/app/pages/SearchResultsPage/SearchResultsPage.tsx
@@ -155,13 +155,6 @@ const InnerSearchResults = ({
     lng: userLocation.lng,
   });
 
-  useEffect(() => {
-    const qsParams = qs.parse(window.location.search.slice(1));
-    qsParams.page = "1";
-    const newUrl = `?${qs.stringify(qsParams)}`;
-    history.replace(newUrl);
-  }, [untranslatedQuery, history]);
-
   return (
     <div className={styles.container}>
       <Helmet>


### PR DESCRIPTION
Closes https://www.notion.so/exygy/Back-button-from-secondary-nav-on-Service-detail-page-won-t-go-to-correct-page-5435c7d2eeee416dbaa52d8b6a74d801

The problem was that there was a line of code setting the url params `page = "1"`, so if a user clicked back from a service page to a search page with params `page=3`, the line would run and revert `page=1`. This was resolved by moving that logic to the `SiteSearchInput`. When a user searches a new query, they should be on page 1 but if they entered a url manually it should maintain the page number in the url. 
