### PR TITLE
[OUR415-195] Fixes incorrect marker location labels

### DIFF
--- a/app/components/search/SearchMap/SearchEntry.tsx
+++ b/app/components/search/SearchMap/SearchEntry.tsx
@@ -15,23 +15,6 @@ interface Props {
 }
 
 export default class SearchEntry extends Component<Props> {
-  renderAddressMetadata() {
-    const { hit } = this.props;
-    const { addresses: rawAddresses } = hit;
-    const addresses = rawAddresses || [];
-
-    if (addresses.length === 0) {
-      return <span>No address found</span>;
-    }
-    if (addresses.length > 1) {
-      return <span>Multiple locations</span>;
-    }
-    if (addresses[0].address_1) {
-      return <span>{addresses[0].address_1}</span>;
-    }
-    return <span>No address found</span>;
-  }
-
   render() {
     const { hit } = this.props;
     const { recurringSchedule, type } = hit;
@@ -57,7 +40,7 @@ export default class SearchEntry extends Component<Props> {
               </p>
             )}
             <p className="entry-meta">
-              {this.renderAddressMetadata()}
+              {hit.addressDisplay}
               {recurringSchedule && (
                 <span className="entry-schedule">
                   <RelativeOpeningTime recurringSchedule={recurringSchedule} />

--- a/app/components/search/SearchMap/SearchMap.tsx
+++ b/app/components/search/SearchMap/SearchMap.tsx
@@ -86,7 +86,7 @@ export const SearchMap = ({
                   key={markerLocation.id}
                   lat={markerLocation.lat}
                   lng={markerLocation.long}
-                  tag={markerLocation.tag}
+                  tag={markerLocation.label}
                   hit={hit}
                 />
               );

--- a/app/components/search/SearchMap/SearchMap.tsx
+++ b/app/components/search/SearchMap/SearchMap.tsx
@@ -80,13 +80,13 @@ export const SearchMap = ({
           <UserLocationMarker lat={lat} lng={lng} key={1} />
           {hits.reduce((markers, hit) => {
             // Add a marker for each address of each hit
-            hit.markerLocations.forEach((markerLocation) => {
+            hit.locations.forEach((location) => {
               markers.push(
                 <GoogleSearchHitMarkerWorkaround
-                  key={markerLocation.id}
-                  lat={markerLocation.lat}
-                  lng={markerLocation.long}
-                  tag={markerLocation.label}
+                  key={location.id}
+                  lat={location.lat}
+                  lng={location.long}
+                  tag={location.label}
                   hit={hit}
                 />
               );

--- a/app/components/search/SearchMap/SearchMap.tsx
+++ b/app/components/search/SearchMap/SearchMap.tsx
@@ -80,17 +80,13 @@ export const SearchMap = ({
           <UserLocationMarker lat={lat} lng={lng} key={1} />
           {hits.reduce((markers, hit) => {
             // Add a marker for each address of each hit
-            hit.addresses?.forEach((addr: any) => {
-              const key = `${hit.id}.${addr.latitude}.${addr.longitude}.${
-                addr.address_1
-              }.${addr.address_2 || ""}`;
-
+            hit.markerLocations.forEach((markerLocation) => {
               markers.push(
                 <GoogleSearchHitMarkerWorkaround
-                  key={key}
-                  lat={addr.latitude}
-                  lng={addr.longitude}
-                  tag={hit.markerTag}
+                  key={markerLocation.id}
+                  lat={markerLocation.lat}
+                  lng={markerLocation.long}
+                  tag={markerLocation.tag}
                   hit={hit}
                 />
               );

--- a/app/components/search/SearchResults/SearchResult.tsx
+++ b/app/components/search/SearchResults/SearchResult.tsx
@@ -15,7 +15,7 @@ export const SearchResult = ({ hit }: { hit: TransformedSearchHit }) => (
         <div className={styles.titleContainer}>
           <div>
             <h2 className={styles.title}>
-              {hit.indexDisplay}.{" "}
+              {hit.resultListIndexDisplay}.{" "}
               <Link
                 to={{ pathname: hit.path }}
                 className={`notranslate ${styles.titleLink}`}

--- a/app/models/SearchHits.ts
+++ b/app/models/SearchHits.ts
@@ -90,6 +90,8 @@ function getLocations(
     // unique ID for use as iteration key
     const id = `${hit.id}.${idx}`;
 
+    // With multiple locations append an incrementing alpha character. For example, if the first result has two
+    // addresses, it would appear on the map with two locations labeled 1A and 1B.
     if (idx > 0) {
       const alphabeticalIndex = (idx + 9).toString(36).toUpperCase();
       label = `${resultListIndexDisplay}${alphabeticalIndex}`;

--- a/app/models/SearchHits.ts
+++ b/app/models/SearchHits.ts
@@ -35,7 +35,7 @@ export interface OrganizationHit
 }
 export type SearchResultsResponse = AlogliaSearchResultsType<SearchHit>;
 export type SearchHit = ServiceHit | OrganizationHit;
-type MarkerLocation = {
+type Location = {
   id: string;
   lat: string;
   long: string;
@@ -51,7 +51,7 @@ export type TransformedSearchHit = Hit<
     geoLocPath: string;
     phoneNumber: string | null;
     websiteUrl: string | null;
-    markerLocations: MarkerLocation[] | [];
+    locations: Location[] | [];
     addressDisplay: string;
   }
 >;
@@ -79,10 +79,10 @@ export const getRecurringScheduleForSeachHit = (
   return result;
 };
 
-function getMarkerLocations(
+function getLocations(
   hit: SearchHit,
   resultListIndexDisplay: string
-): MarkerLocation[] | [] {
+): Location[] | [] {
   if (!hit.addresses) return [];
 
   return hit.addresses.map((address, idx) => {
@@ -145,7 +145,7 @@ export function transformSearchResults(
       geoLocPath: `http://google.com/maps/dir/?api=1&destination=${hit._geoloc.lat},${hit._geoloc.lng}`,
       phoneNumber,
       websiteUrl,
-      markerLocations: getMarkerLocations(hit, resultListIndexDisplay),
+      locations: getLocations(hit, resultListIndexDisplay),
       addressDisplay: getAddressDisplay(hit),
     };
 

--- a/app/models/SearchHits.ts
+++ b/app/models/SearchHits.ts
@@ -86,20 +86,20 @@ function getLocations(
   if (!hit.addresses) return [];
 
   return hit.addresses.map((address, idx) => {
-    let markerLabel = resultListIndexDisplay;
+    let label = resultListIndexDisplay;
     // unique ID for use as iteration key
     const id = `${hit.id}.${idx}`;
 
     if (idx > 0) {
       const alphabeticalIndex = (idx + 9).toString(36).toUpperCase();
-      markerLabel = `${resultListIndexDisplay}${alphabeticalIndex}`;
+      label = `${resultListIndexDisplay}${alphabeticalIndex}`;
     }
 
     return {
       id,
       lat: address.latitude,
       long: address.longitude,
-      label: markerLabel,
+      label,
     };
   });
 }

--- a/app/models/SearchHits.ts
+++ b/app/models/SearchHits.ts
@@ -39,7 +39,7 @@ type MarkerLocation = {
   id: string;
   lat: string;
   long: string;
-  tag: string;
+  label: string;
 };
 export type TransformedSearchHit = Hit<
   SearchHit & {
@@ -86,20 +86,20 @@ function getMarkerLocations(
   if (!hit.addresses) return [];
 
   return hit.addresses.map((address, idx) => {
-    let markerTag = resultListIndexDisplay;
+    let markerLabel = resultListIndexDisplay;
     // unique ID for use as iteration key
     const id = `${hit.id}.${idx}`;
 
     if (idx > 0) {
       const alphabeticalIndex = (idx + 9).toString(36).toUpperCase();
-      markerTag = `${resultListIndexDisplay}${alphabeticalIndex}`;
+      markerLabel = `${resultListIndexDisplay}${alphabeticalIndex}`;
     }
 
     return {
       id,
       lat: address.latitude,
       long: address.longitude,
-      tag: markerTag,
+      label: markerLabel,
     };
   });
 }


### PR DESCRIPTION
My [previous solution](https://github.com/Exygy/askdarcel-web/pull/98) was incomplete as I forgot to move the marker label computation logic into the new transform. Map marker labels were rendering out either duplicate or incorrectly indexed because I wasn't actually using addresses to create the label. 

Before: 
![image](https://github.com/user-attachments/assets/0afb00fd-f417-41f2-b300-c9496d6edb0c)

After:
![image](https://github.com/user-attachments/assets/0792c3e2-1ab5-43da-b957-64080dffdb74)
