### PR TITLE
Add screen-reader only headers to site where missing (a11y)

### DIFF
--- a/app/components/search/Header/Header.tsx
+++ b/app/components/search/Header/Header.tsx
@@ -33,6 +33,7 @@ export const Header = ({
     <div className={styles.header}>
       <div className={styles.headerInner}>
         <div>
+          <h2 className="sr-only">Browse services by category</h2>
           <Dropdown
             categories={CATEGORIES}
             currentCategory={currentCategory}

--- a/app/components/search/Header/Header.tsx
+++ b/app/components/search/Header/Header.tsx
@@ -33,9 +33,6 @@ export const Header = ({
     <div className={styles.header}>
       <div className={styles.headerInner}>
         <div>
-          <h1 className="sr-only">
-            {title === resultsTitle ?? "Search results"}
-          </h1>
           <Dropdown
             categories={CATEGORIES}
             currentCategory={currentCategory}

--- a/app/components/search/Header/SearchHeaderSection.module.scss
+++ b/app/components/search/Header/SearchHeaderSection.module.scss
@@ -13,15 +13,23 @@
 
   .searchHeaderContainerLeft {
     display: flex;
+    align-items: center;
     gap: $spacing-6;
+
+    h1 {
+      font-size: 26px;
+      min-height: 100%;
+      line-height: 100%;
+    }
 
     @include r_max($break-tablet-s) {
       display: block;
       width: 100%;
       margin-bottom: $spacing-2;
 
-      h2 {
+      h1 {
         margin-bottom: $spacing-2;
+        font-size: 20px;
       }
     }
   }

--- a/app/components/search/Header/SearchHeaderSection.tsx
+++ b/app/components/search/Header/SearchHeaderSection.tsx
@@ -11,9 +11,8 @@ export const SearchHeaderSection = ({
   descriptionText: string;
 }) => (
   <div className={styles.searchHeaderContainer}>
-    {/* mobileInnerContainer ^ */}
     <div className={styles.searchHeaderContainerLeft}>
-      <h2>Services</h2>
+      <h1 className={styles.title}>Services</h1>
       <SiteSearchInput />
     </div>
     <span>{descriptionText}</span>

--- a/app/components/search/SearchMap/SearchMap.tsx
+++ b/app/components/search/SearchMap/SearchMap.tsx
@@ -48,6 +48,7 @@ export const SearchMap = ({
 
   return (
     <div className="results-map">
+      <h2 className="sr-only">Map of search results</h2>
       <div className="map-wrapper">
         {/* If map is being overlaid, hide the search area button. It is is neither clickable
             nor relevant in this mode.

--- a/app/components/search/SearchResults/SearchResults.tsx
+++ b/app/components/search/SearchResults/SearchResults.tsx
@@ -64,6 +64,7 @@ const SearchResults = ({
           mobileMapIsCollapsed ? styles.mobileMapIsCollapsed : ""
         }`}
       >
+        <h2 className="sr-only">Search results</h2>
         {hasNoResults ? (
           <NoResultsDisplay />
         ) : (

--- a/app/pages/HomePage/HomePage.tsx
+++ b/app/pages/HomePage/HomePage.tsx
@@ -30,6 +30,7 @@ export const HomePage = () => {
 
   return (
     <>
+      <h1 className="sr-only">Homepage</h1>
       {hero && (
         <Hero
           backgroundImage={hero.background_image.data?.attributes.url ?? ""}

--- a/app/styles/st-base/_layout.scss
+++ b/app/styles/st-base/_layout.scss
@@ -129,6 +129,19 @@ pre {
   }
 }
 
+// Screen reader only
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 .no-transition {
   -webkit-transition: none !important;
   -moz-transition: none !important;


### PR DESCRIPTION
Closes `Add hidden sr-only headers to sections for a11y (i.e. search results, pagination)` todo of https://www.notion.so/exygy/a11y-bugs-cf30e04daa794b04879af76207b9b96a

This PR adds visually hidden headers around the site where they are missing to improve user a11y:
- h1 on homepage
- h1 on search results page (remove old h1)
- add h2s on search results page to let user know what each section is for
