### PR TITLE
Focus State Update

### DIFF
--- a/app/components/ui/Navigation/NavigationFocusReset.tsx
+++ b/app/components/ui/Navigation/NavigationFocusReset.tsx
@@ -2,24 +2,33 @@ import React, { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 
 /* 
-  Resets focus state for a11y, by focusing and unfocusing an off-screen element at the top of the page when page location changes
-  Since filters change the location, the logic is to only reset focus when a main-level page change occurs (not when user filters a search)
+  Resets focus state for a11y by focusing and unfocusing an off-screen element at the top of the page when the page location changes.
+  The focus reset occurs on all page location changes except for top-level category and search page filter changes.
 */
 export const NavigationFocusReset: React.FC = () => {
   const location = useLocation();
   const hiddenInputRef = useRef<HTMLInputElement | null>(null);
-  const previousPathSegmentRef = useRef<string>("");
+  const previousPathRef = useRef<string>("");
 
   useEffect(() => {
-    const currentPathSegment = location.pathname.split("/")[1];
+    const currentPath = location.pathname;
 
-    if (currentPathSegment !== previousPathSegmentRef.current) {
+    const isCategoryPage = currentPath.includes("results");
+    const isSearchPage = currentPath.includes("query");
+    const pathHasFilters = isCategoryPage || isSearchPage;
+
+    // Check if the current path is different from the previous path
+    const pathChanged = currentPath !== previousPathRef.current;
+
+    // Focus reset should occur if the path changed and it's not just a filter change
+    if (pathChanged && (!pathHasFilters || previousPathRef.current === "")) {
       if (hiddenInputRef.current) {
         hiddenInputRef.current.focus();
         hiddenInputRef.current.blur();
       }
-      previousPathSegmentRef.current = currentPathSegment;
     }
+
+    previousPathRef.current = currentPath;
   }, [location]);
 
   return (

--- a/app/components/ui/Navigation/NavigationFocusReset.tsx
+++ b/app/components/ui/Navigation/NavigationFocusReset.tsx
@@ -1,16 +1,24 @@
 import React, { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 
-// Resets focus state for a11y, by focusing and unfocusing an off-screen element at the top of the page when page location changes
-
-export const NavigationFocusReset = () => {
+/* 
+  Resets focus state for a11y, by focusing and unfocusing an off-screen element at the top of the page when page location changes
+  Since filters change the location, the logic is to only reset focus when a main-level page change occurs (not when user filters a search)
+*/
+export const NavigationFocusReset: React.FC = () => {
   const location = useLocation();
   const hiddenInputRef = useRef<HTMLInputElement | null>(null);
+  const previousPathSegmentRef = useRef<string>("");
 
   useEffect(() => {
-    if (hiddenInputRef.current) {
-      hiddenInputRef.current.focus();
-      hiddenInputRef.current.blur();
+    const currentPathSegment = location.pathname.split("/")[1];
+
+    if (currentPathSegment !== previousPathSegmentRef.current) {
+      if (hiddenInputRef.current) {
+        hiddenInputRef.current.focus();
+        hiddenInputRef.current.blur();
+      }
+      previousPathSegmentRef.current = currentPathSegment;
     }
   }, [location]);
 

--- a/app/components/ui/Navigation/NavigationFocusReset.tsx
+++ b/app/components/ui/Navigation/NavigationFocusReset.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 
 /* 
-  Resets focus state for a11y by focusing and unfocusing an off-screen element at the top of the page when the page location changes.
-  The focus reset occurs on all page location changes except for top-level category and search page filter changes.
+  Resets focus state for a11y by focusing and unfocusing an off-screen element 
+  at the top of the page when the page location changes.
+  The focus reset occurs on all page location changes except when only the query string changes.
 */
 export const NavigationFocusReset: React.FC = () => {
   const location = useLocation();
@@ -11,21 +12,14 @@ export const NavigationFocusReset: React.FC = () => {
   const previousPathRef = useRef<string>("");
 
   useEffect(() => {
-    const currentPath = location.pathname;
+    const currentPath = location.pathname + location.search;
 
-    const isCategoryPage = currentPath.includes("results");
-    const isSearchPage = currentPath.includes("query");
-    const pathHasFilters = isCategoryPage || isSearchPage;
-
-    // Check if the current path is different from the previous path
     const pathChanged = currentPath !== previousPathRef.current;
 
-    // Focus reset should occur if the path changed and it's not just a filter change
-    if (pathChanged && (!pathHasFilters || previousPathRef.current === "")) {
-      if (hiddenInputRef.current) {
-        hiddenInputRef.current.focus();
-        hiddenInputRef.current.blur();
-      }
+    // Focus reset should occur if the path changed and it's not just a query string change
+    if (pathChanged && !location.search && hiddenInputRef.current) {
+      hiddenInputRef.current.focus();
+      hiddenInputRef.current.blur();
     }
 
     previousPathRef.current = currentPath;


### PR DESCRIPTION
This PR adds a quick fix to NavigationFocusReset so that it only resets user focus when they switch top-level pages and NOT when they use the eligibility filters or search something new from a /search page. This improves UX and a11y so that the user does not have to tab nav from the top of the page when they select a checkbox or radio button.

