### PR TITLE
Print view ux edits

### DIFF
--- a/app/components/search/Header/Header.tsx
+++ b/app/components/search/Header/Header.tsx
@@ -57,7 +57,7 @@ export const Header = ({
             showPrintResultsBtn ? styles.showBtn : ""
           }`}
         >
-          Print all results
+          Print this page
         </Button>
       </div>
     </div>

--- a/app/components/search/SearchResults/SearchResult.tsx
+++ b/app/components/search/SearchResults/SearchResult.tsx
@@ -53,6 +53,14 @@ export const SearchResult = ({ hit }: { hit: TransformedSearchHit }) => (
           </div>
         </div>
       </div>
+      <div className="print-only">
+        <p>
+          <strong>Call:</strong> {hit.phoneNumber}
+        </p>
+        <p>
+          <strong>Website:</strong> {hit.websiteUrl}
+        </p>
+      </div>
       <div className={styles.searchResultContent}>
         <div className={styles.searchText}>
           <div className={`notranslate ${styles.address}`}>
@@ -71,7 +79,7 @@ export const SearchResult = ({ hit }: { hit: TransformedSearchHit }) => (
         </div>
       </div>
     </div>
-    <div className={styles.sideLinks}>
+    <div className={`${styles.sideLinks} no-print`}>
       {hit.phoneNumber && (
         <a
           href={`tel:${hit.phoneNumber}`}

--- a/app/components/ui/BackButton.tsx
+++ b/app/components/ui/BackButton.tsx
@@ -21,8 +21,14 @@ export const BackButton = ({
       : () => history.goBack();
 
   return (
-    <Button onClick={backDestination} variant="linkWhite" arrowVariant="before">
-      {children}
-    </Button>
+    <span className="no-print">
+      <Button
+        onClick={backDestination}
+        variant="linkWhite"
+        arrowVariant="before"
+      >
+        {children}
+      </Button>
+    </span>
   );
 };

--- a/app/components/ui/Footer/Footer.tsx
+++ b/app/components/ui/Footer/Footer.tsx
@@ -22,7 +22,7 @@ export const Footer = () => {
   }
 
   return (
-    <footer className="site-footer" role="contentinfo">
+    <footer className="site-footer no-print" role="contentinfo">
       <div className="site-footer__content">
         <div className="site-footer__top">
           <div className="site-footer__contact">

--- a/app/components/ui/Navigation/Navigation.tsx
+++ b/app/components/ui/Navigation/Navigation.tsx
@@ -63,7 +63,7 @@ export const Navigation = () => {
               </Link>
             </div>
 
-            <div className={`${styles.navRight}`}>
+            <div className={`${styles.navRight} no-print`}>
               <div className={styles.desktopNavigationContainer}>
                 {menuData?.map((menuDataItem) => (
                   <DesktopMenuItems

--- a/app/styles/st-base/_layout.scss
+++ b/app/styles/st-base/_layout.scss
@@ -122,10 +122,22 @@ pre {
   }
 }
 
-// Hide from print view
 @media print {
+  // Hide from print view
   .no-print {
     display: none !important;
+  }
+
+  // Only show in print view
+  .print-only {
+    display: block;
+  }
+}
+
+@media screen {
+  // Don't show in non-print view
+  .print-only {
+    display: none;
   }
 }
 


### PR DESCRIPTION
This PR closes the following todos:
- [Search Page] Print view on (/search) should include phone number and website rather than icons
- [Search Page] “Print All Results” only prints current page (I don’t know if we can fix this) Maybe we should change the copy to Print this page.
- [Sitewide] Hide header and footer from print view using “.no-print” class
from Visual bugs muliticket https://www.notion.so/exygy/Visual-bugs-c3450de5b2944517b933df773dd1deef

IMO these aren't a huge deal but since we are including a print button on the site, the print page should provide value (i.e. include phone numbers and URLs that are visually hidden on site) and hide components that don't provide value (i.e. footer)