### PR TITLE
Close eligibilities sidebar on click away

### DIFF
--- a/app/components/search/Header/CustomDropdown.module.scss
+++ b/app/components/search/Header/CustomDropdown.module.scss
@@ -30,7 +30,7 @@
   top: 50px;
   min-width: 160px;
   box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.2);
-  z-index: 999;
+  z-index: $z-index-top;
   list-style: none;
   padding: 0;
   margin: 0;

--- a/app/components/search/Sidebar/Sidebar.module.scss
+++ b/app/components/search/Sidebar/Sidebar.module.scss
@@ -35,6 +35,7 @@
     height: auto;
     width: 60%;
     padding: 0;
+    z-index: 998; // higher than everything except dropdown menu
     align-self: flex-start;
     border-right: 0;
     background-color: #fff;

--- a/app/components/search/Sidebar/Sidebar.module.scss
+++ b/app/components/search/Sidebar/Sidebar.module.scss
@@ -35,7 +35,7 @@
     height: auto;
     width: 60%;
     padding: 0;
-    z-index: 998; // higher than everything except dropdown menu
+    z-index: $z-index-modal;
     align-self: flex-start;
     border-right: 0;
     background-color: #fff;

--- a/app/components/search/Sidebar/Sidebar.tsx
+++ b/app/components/search/Sidebar/Sidebar.tsx
@@ -1,8 +1,5 @@
 import React, { useState, useRef } from "react";
-import useClickOutside from "../../../hooks/MenuHooks";
-
 import type { Category } from "models/Meta";
-
 import {
   eligibilitiesMapping,
   categoriesMapping,
@@ -12,6 +9,7 @@ import OpenNowFilter from "components/search/Refinements/OpenNowFilter";
 import RefinementListFilter from "components/search/Refinements/RefinementListFilter";
 import FacetRefinementList from "components/search/Refinements/FacetRefinementList";
 import { Button } from "components/ui/inline/Button/Button";
+import useClickOutside from "../../../hooks/MenuHooks";
 import MobileMapToggleButtons from "./MobileMapToggleButtons";
 import styles from "./Sidebar.module.scss";
 

--- a/app/components/search/Sidebar/Sidebar.tsx
+++ b/app/components/search/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 
 import type { Category } from "models/Meta";
 
@@ -36,6 +36,29 @@ const Sidebar = ({
   setIsMapCollapsed: (_isMapCollapsed: boolean) => void;
 }) => {
   const [filterMenuVisible, setfilterMenuVisible] = useState(false);
+  const filterMenuRef = useRef<HTMLDivElement>(null);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      filterMenuRef.current &&
+      !filterMenuRef.current.contains(event.target as Node)
+    ) {
+      setfilterMenuVisible(false);
+    }
+  };
+
+  useEffect(() => {
+    if (filterMenuVisible) {
+      document.addEventListener("mousedown", handleClickOutside);
+    } else {
+      document.removeEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [filterMenuVisible]);
+
   let categoryRefinementJsx: React.ReactElement | null = null;
   let eligibilityRefinementJsx: React.ReactElement | null = null;
   const orderByLabel = (a: { label: string }, b: { label: string }) =>
@@ -142,6 +165,7 @@ const Sidebar = ({
         />
       </div>
       <div
+        ref={filterMenuRef}
         className={`${styles.filtersContainer} ${
           filterMenuVisible ? styles.showFilters : ""
         }`}

--- a/app/components/search/Sidebar/Sidebar.tsx
+++ b/app/components/search/Sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useRef } from "react";
+import useClickOutside from "../../../hooks/MenuHooks";
 
 import type { Category } from "models/Meta";
 
@@ -38,26 +39,11 @@ const Sidebar = ({
   const [filterMenuVisible, setfilterMenuVisible] = useState(false);
   const filterMenuRef = useRef<HTMLDivElement>(null);
 
-  const handleClickOutside = (event: MouseEvent) => {
-    if (
-      filterMenuRef.current &&
-      !filterMenuRef.current.contains(event.target as Node)
-    ) {
-      setfilterMenuVisible(false);
-    }
-  };
-
-  useEffect(() => {
-    if (filterMenuVisible) {
-      document.addEventListener("mousedown", handleClickOutside);
-    } else {
-      document.removeEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [filterMenuVisible]);
+  useClickOutside(
+    filterMenuRef,
+    () => setfilterMenuVisible(false),
+    filterMenuVisible
+  );
 
   let categoryRefinementJsx: React.ReactElement | null = null;
   let eligibilityRefinementJsx: React.ReactElement | null = null;

--- a/app/components/ui/Navigation/DesktopNavigation.module.scss
+++ b/app/components/ui/Navigation/DesktopNavigation.module.scss
@@ -20,7 +20,7 @@
 
 .navigationSubMenu {
   position: absolute;
-  z-index: 999;
+  z-index: $z-index-top;
   top: 65px;
   background: $white;
   box-shadow: 0px 4px 6px -1px #0000001a;

--- a/app/components/ui/Navigation/DropdownMenu.module.scss
+++ b/app/components/ui/Navigation/DropdownMenu.module.scss
@@ -20,7 +20,7 @@
 
 .navigationSubMenu {
   position: absolute;
-  z-index: 999;
+  z-index: $z-index-top;
   top: 65px;
   background: $white;
   box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.2);

--- a/app/components/ui/Navigation/MobileNavigation.module.scss
+++ b/app/components/ui/Navigation/MobileNavigation.module.scss
@@ -81,7 +81,7 @@
 
 .mobileNavigationMenuList {
   position: absolute;
-  z-index: 999;
+  z-index: $z-index-top;
   overflow: hidden;
   top: 0;
   border-radius: 0;

--- a/app/components/ui/Navigation/SkipButton.module.scss
+++ b/app/components/ui/Navigation/SkipButton.module.scss
@@ -4,7 +4,7 @@
   background-color: #000;
   color: #fff;
   padding: 8px 16px;
-  z-index: 1000;
+  z-index: $z-index-top;
   transition: top 0.3s;
   text-decoration: none;
 }

--- a/app/components/ui/Navigation/SkipButton.module.scss
+++ b/app/components/ui/Navigation/SkipButton.module.scss
@@ -1,3 +1,6 @@
+@import "../../../styles/utils/_helpers.scss";
+@import "../../../styles/utils/_colors.scss";
+
 .skipToMain {
   position: absolute;
   top: -40px;

--- a/app/hooks/MenuHooks.ts
+++ b/app/hooks/MenuHooks.ts
@@ -43,3 +43,28 @@ export function useMenuToggle() {
     menuRef,
   };
 }
+
+// For use in modals, dropdowns, etc.
+function useClickOutside<T extends HTMLElement>(
+  ref: React.RefObject<T>,
+  callback: () => void, // i.e. setIsActive(false)
+  isActive: boolean = true
+) {
+  useEffect(() => {
+    if (!isActive) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [ref, callback, isActive]);
+}
+
+export default useClickOutside;

--- a/app/hooks/MenuHooks.ts
+++ b/app/hooks/MenuHooks.ts
@@ -51,18 +51,20 @@ function useClickOutside<T extends HTMLElement>(
   isActive: boolean = true
 ) {
   useEffect(() => {
-    if (!isActive) return;
-
     const handleClickOutside = (event: MouseEvent) => {
       if (ref.current && !ref.current.contains(event.target as Node)) {
         callback();
       }
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
+    if (isActive) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
 
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      if (isActive) {
+        document.removeEventListener("mousedown", handleClickOutside);
+      }
     };
   }, [ref, callback, isActive]);
 }

--- a/app/styles/utils/_layoututils.scss
+++ b/app/styles/utils/_layoututils.scss
@@ -27,6 +27,7 @@ $z-index-edit-address-modal: 1;
 $z-index-site-nav: 3;
 $z-index-filters-menu: 4;
 $z-index-modal: 5;
+$z-index-top: 9;
 
 %flex-row {
   @include display(flex);


### PR DESCRIPTION
This PR addresses `[Search Page] Filters sidebar should close on click away (/search)` todo of visual bugs multi ticket https://www.notion.so/exygy/Visual-bugs-c3450de5b2944517b933df773dd1deef

It also adds a z-index back in that was causing visual errors with the sidebar being hidden by map.