### PR TITLE
Icon size bug

### DIFF
--- a/app/components/ui/Navigation/DesktopNavigation.module.scss
+++ b/app/components/ui/Navigation/DesktopNavigation.module.scss
@@ -87,10 +87,6 @@
   }
 }
 
-.navigationMenuHeader .chevron {
-  font-size: 12px;
-}
-
 .desktopNavigationContainer {
   display: flex;
   flex-direction: row;

--- a/app/components/ui/Navigation/DropdownMenu.module.scss
+++ b/app/components/ui/Navigation/DropdownMenu.module.scss
@@ -87,10 +87,6 @@
   }
 }
 
-.navigationMenuHeader .chevron {
-  font-size: 12px;
-}
-
 .categoryMenuContainer {
   position: relative;
   min-width: 160px;

--- a/app/components/ui/inline/Button/Button.module.scss
+++ b/app/components/ui/inline/Button/Button.module.scss
@@ -7,6 +7,8 @@
   height: fit-content;
   width: fit-content;
   white-space: nowrap;
+  display: flex;
+  align-items: center;
 
   &:disabled {
     color: $white;
@@ -137,6 +139,11 @@
       margin-left: 8px;
     }
   }
+}
+
+.icon-after,
+.icon-before {
+  font-size: 24px;
 }
 
 .icon-before {


### PR DESCRIPTION
Fixes `Fix tiny icons` bug in https://www.notion.so/exygy/Visual-bugs-c3450de5b2944517b933df773dd1deef

Two separate issues that seemed like a more systemic problem but are not. Button icons and dropdown chevron were both too small and this PR restores their former correct sizes.