### PR TITLE
Mobile QA multi

### DIFF
--- a/app/components/listing/ListingPageWrapper.module.scss
+++ b/app/components/listing/ListingPageWrapper.module.scss
@@ -27,6 +27,7 @@
   }
 
   p,
+  li,
   a,
   table {
     @include r_max($break-tablet-s) {

--- a/app/components/search/Header/Header.module.scss
+++ b/app/components/search/Header/Header.module.scss
@@ -13,7 +13,7 @@
   display: flex;
   max-width: $width-navigation;
   margin: 0 auto;
-  padding: $general-spacing-md;
+  padding: $general-spacing-md $general-spacing-xxs;
   justify-content: space-between;
   align-items: center;
   border-bottom: 1px solid $color-grey3;

--- a/app/components/search/Header/Header.module.scss
+++ b/app/components/search/Header/Header.module.scss
@@ -17,6 +17,10 @@
   justify-content: space-between;
   align-items: center;
   border-bottom: 1px solid $color-grey3;
+
+  @media screen and (max-width: $break-tablet-s) {
+    padding: $general-spacing-s $general-spacing-xxs;
+  }
 }
 
 .title {

--- a/app/components/search/Header/SearchHeaderSection.module.scss
+++ b/app/components/search/Header/SearchHeaderSection.module.scss
@@ -25,10 +25,10 @@
     @include r_max($break-tablet-s) {
       display: block;
       width: 100%;
-      margin-bottom: $spacing-2;
+      margin-bottom: $general-spacing-md;
 
       h1 {
-        margin-bottom: $spacing-2;
+        margin-bottom: $general-spacing-md;
         font-size: 20px;
       }
     }

--- a/app/components/search/SearchResults/SearchResults.module.scss
+++ b/app/components/search/SearchResults/SearchResults.module.scss
@@ -200,7 +200,7 @@
   font-size: 18px;
   color: $color-brand;
 
-  @media screen and (max-width: $break-tablet-s) {
+  @media screen and (max-width: $break-tablet-p) {
     font-size: 16px;
     display: flex;
     gap: $general-spacing-md;

--- a/app/components/search/SearchResults/SearchResults.module.scss
+++ b/app/components/search/SearchResults/SearchResults.module.scss
@@ -110,6 +110,10 @@
     border-bottom: 1px solid $border-gray;
     flex-direction: column;
     width: 100vw;
+
+    p {
+      font-size: 14px;
+    }
   }
 }
 
@@ -298,10 +302,6 @@
     display: block;
     padding: 20px 0;
     border-left: 0;
-
-    li {
-      font-size: 16px;
-    }
   }
 
   .sideLink {

--- a/app/components/search/SearchResults/SearchResults.module.scss
+++ b/app/components/search/SearchResults/SearchResults.module.scss
@@ -116,8 +116,8 @@
 .searchResultContentContainer {
   width: 100%;
   max-width: 584px;
-  @media screen and (max-width: $break-tablet-s) {
-    max-width: 100vw;
+  @media screen and (max-width: $break-tablet-p) {
+    max-width: 100%;
   }
 }
 

--- a/app/components/search/Sidebar/Sidebar.module.scss
+++ b/app/components/search/Sidebar/Sidebar.module.scss
@@ -33,7 +33,7 @@
 
   @media screen and (max-width: $break-desktop-s) {
     height: auto;
-    width: 60%;
+    width: 100%;
     padding: 0;
     z-index: $z-index-modal;
     align-self: flex-start;

--- a/app/components/ui/Accordions/Accordion.module.scss
+++ b/app/components/ui/Accordions/Accordion.module.scss
@@ -5,7 +5,7 @@
   margin: $general-spacing-lg auto $spacing-0;
 
   @include r_max($break-desktop-s) {
-    margin: $general-spacing-lg $spacing-0 $spacing-0;
+    margin: $spacing-0 $spacing-0;
     max-width: 100%;
   }
 

--- a/app/components/ui/Accordions/Accordion.module.scss
+++ b/app/components/ui/Accordions/Accordion.module.scss
@@ -6,10 +6,10 @@
 
   @include r_max($break-desktop-s) {
     margin: $general-spacing-lg $spacing-0 $spacing-0;
+    max-width: 100%;
   }
 
   @include r_max($break-tablet-s) {
-    max-width: 100%;
   }
 
   .accordionItem {
@@ -35,6 +35,7 @@
 
   .accordionTitle {
     display: flex;
+    gap: $general-spacing-md;
     justify-content: space-between;
     align-items: center;
     font-family: Montserrat;
@@ -43,6 +44,7 @@
     width: 100%;
     margin: 0;
     font-size: 18px;
+    text-align: left;
   }
 
   .accordionContent {

--- a/app/components/ui/Hero/Hero.tsx
+++ b/app/components/ui/Hero/Hero.tsx
@@ -61,6 +61,7 @@ const HeroCard = ({
             <Button
               key={button.text}
               variant={i === 0 ? "primary" : "secondary"}
+              size="lg"
               arrowVariant="after"
               href={button.url}
             >

--- a/app/components/ui/Masthead/Masthead.module.scss
+++ b/app/components/ui/Masthead/Masthead.module.scss
@@ -12,6 +12,7 @@
 
 .mastheadHeader {
   color: $text-tertiary;
+  line-height: 100%;
 }
 
 @media screen and (max-width: $break-tablet-p) {

--- a/app/pages/ServiceListingPage/ServiceListingPage.module.scss
+++ b/app/pages/ServiceListingPage/ServiceListingPage.module.scss
@@ -5,6 +5,10 @@
   font-size: 18px;
   @include r_max($break-tablet-s) {
     font-size: 16px;
+
+    a {
+      font-size: 16px;
+    }
   }
 }
 

--- a/app/styles/st-base/_layout.scss
+++ b/app/styles/st-base/_layout.scss
@@ -122,7 +122,8 @@ pre {
   }
 }
 
-button {
+button,
+select {
   color: $color-tertiary;
 }
 

--- a/app/styles/utils/_helpers.scss
+++ b/app/styles/utils/_helpers.scss
@@ -22,7 +22,6 @@ $font-family-base: "Inter", "Montserrat", "Open Sans", "Helvetica Neue", "Arial"
 // FONT SIZES
 
 %font-size-x-large {
-  min-height: 3rem;
   font-size: 3rem;
   line-height: 125%;
   @include r_max($break-tablet-p) {


### PR DESCRIPTION
This PR closes the following items of https://www.notion.so/exygy/Responsiveness-bugs-49256bf5cc954630be508a01b54eb457:

- [Search] On search listings cards, list items font is smaller than rest of text
- [Search] Search icon is white on mobile but should be black
- [Service] Individual service page: link in subhead smaller than rest of text
- [FAQs] Accordion headers are centered on mobile but should not be

as well as some visual bugs I noticed in the process:
- Google translate select dropdown was blue on mobile but should be black
- Search results cards tablet size visual bugs
- Hero buttons on homepage were too big
- There were some spacing discrepancies on mobile /search
- DropdownMenu on /search page text did align with rest of content (due to padding)
- Sticky filters header was only 60% screen width, now 100%
- Masthead H1 was min height 3rem but font-size was only 28px, causing strange spacing
- Accordion had too much top margin on mobile