### PR TITLE
[OUR415-193] Converts search results from grid to flex with min width for result list

### DIFF
--- a/app/components/search/SearchMap/SearchMap.scss
+++ b/app/components/search/SearchMap/SearchMap.scss
@@ -5,15 +5,16 @@
 }
 
 .results-map {
+  position: sticky;
   width: 100%;
   min-width: 300px;
+  height: calc(100vh - 265px);
 
   @media screen and (max-width: $break-tablet-p) {
     height: 25rem;
   }
 
   @media screen and (max-width: $break-tablet-s) {
-    position: relative;
     min-height: 250px;
   }
 }

--- a/app/components/search/SearchMap/SearchMap.scss
+++ b/app/components/search/SearchMap/SearchMap.scss
@@ -8,7 +8,8 @@
   position: sticky;
   width: 100%;
   min-width: 300px;
-  height: calc(100vh - 265px);
+  height: calc(100vh - 290px);
+  top: $header-height;
 
   @media screen and (max-width: $break-tablet-p) {
     height: 25rem;

--- a/app/components/search/SearchMap/SearchMap.scss
+++ b/app/components/search/SearchMap/SearchMap.scss
@@ -5,11 +5,8 @@
 }
 
 .results-map {
-  position: sticky;
   width: 100%;
   min-width: 300px;
-  height: 50rem;
-  top: $header-height;
 
   @media screen and (max-width: $break-tablet-p) {
     height: 25rem;
@@ -17,7 +14,6 @@
 
   @media screen and (max-width: $break-tablet-s) {
     position: relative;
-    top: 0;
     min-height: 250px;
   }
 }

--- a/app/components/search/SearchMap/SearchMap.scss
+++ b/app/components/search/SearchMap/SearchMap.scss
@@ -8,7 +8,7 @@
   position: sticky;
   width: 100%;
   min-width: 300px;
-  height: calc(100vh - 290px);
+  height: calc(100vh - $header-height);
   top: $header-height;
 
   @media screen and (max-width: $break-tablet-p) {

--- a/app/components/search/SearchResults/SearchResults.module.scss
+++ b/app/components/search/SearchResults/SearchResults.module.scss
@@ -1,19 +1,10 @@
 @import "~styles/utils/_helpers.scss";
 
 .searchResultsAndMapContainer {
-  display: grid;
-  grid-template-columns: 6fr 4fr;
-  grid-template-areas:
-    "toggle toggle"
-    "results map";
+  display: flex;
 
   @media screen and (max-width: $break-tablet-p) {
-    grid-template-columns: auto;
-    grid-template-rows: auto auto;
-    grid-template-areas:
-      "map"
-      "toggle"
-      "results";
+    flex-direction: column-reverse;
   }
 }
 
@@ -22,6 +13,7 @@
   display: grid;
   gap: $general-spacing-md;
   margin: $spacing-0 $general-spacing-lg;
+  flex: 0 0 40em;
 
   @media screen and (max-width: $break-desktop-s) {
     margin: $spacing-0 $general-spacing-md;


### PR DESCRIPTION
🎟️ : [notion.so/exygy/Zoom-level-cuts-off-some-results-33c6ba214bb44c34b67edf9443e1c75c?pvs=4](https://www.notion.so/exygy/Zoom-level-cuts-off-some-results-33c6ba214bb44c34b67edf9443e1c75c?pvs=4)

Before:
https://github.com/user-attachments/assets/7610b4e9-f561-4646-ad68-6e58beee6500

After: 

https://github.com/user-attachments/assets/b59ed537-d7e7-4296-84c7-03f617d438c5

