### PR TITLE
[OUR415-239] Removes sensitive data from example config

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -7,13 +7,13 @@
 # - Street View API
 # Note that the settings for this key are in Google Cloud Platform under the
 # AskDarcel project
-GOOGLE_API_KEY: "AIzaSyAz2oiKYp048xbbjXH54PrNDdQO38I6-pc"
+GOOGLE_API_KEY: "<ENTER_YOUR_GOOGLE_API_KEY_HERE>"
 
 # Please replace the entire value of the ALGOLIA_INDEX_PREFIX setting with your
 # GitHub username, including the < and > symbols.
 ALGOLIA_INDEX_PREFIX: "<ENTER_YOUR_GITHUB_USERNAME_HERE>"
-ALGOLIA_APPLICATION_ID: "J8TVT53HPZ"
-ALGOLIA_READ_ONLY_API_KEY: "fdf77b152ff7ce0ea4e4221ff3d17d85"
+ALGOLIA_APPLICATION_ID: "<ENTER_YOUR_ALGOLIA_APPLICATION_ID_HERE>"
+ALGOLIA_READ_ONLY_API_KEY: "<ENTER_YOUR_ALGOLIA_READ_ONLY_API_KEY_HERE>"
 
 STRAPI_API_TOKEN: ""
 STRAPI_API_URL: ""


### PR DESCRIPTION
🎫 [Reconcile config vars across Github Environment secrets and Heroku](https://www.notion.so/exygy/Reconcile-config-vars-across-Github-Environment-secrets-and-Heroku-db5caf384b0e450883c6eec5ad06ef63?pvs=4)