### PR TITLE
[OUR415-300] Adds fallback to fetch a Service directly from Algolia if missing from the Shelter Tech API

### DIFF
--- a/app/components/ui/Navigation/Navigation.tsx
+++ b/app/components/ui/Navigation/Navigation.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import styles from "components/ui/Navigation/Navigation.module.scss";
 import { GoogleTranslate } from "components/ui/GoogleTranslate";

--- a/app/pages/ServiceListingPage/ServiceListingPage.tsx
+++ b/app/pages/ServiceListingPage/ServiceListingPage.tsx
@@ -97,7 +97,6 @@ export const ServiceListingPage = () => {
     fetchServiceOrFallback();
   }, [id, pathname]);
 
-  // NOTE:
   if (serviceFallback) {
     const formattedLongDescription = serviceFallback.long_description
       ? removeAsterisksAndHashes(serviceFallback.long_description)

--- a/app/pages/ServiceListingPage/ServiceListingPage.tsx
+++ b/app/pages/ServiceListingPage/ServiceListingPage.tsx
@@ -26,33 +26,121 @@ import {
   Service,
 } from "../../models";
 import styles from "./ServiceListingPage.module.scss";
+import { algoliasearch } from "algoliasearch";
+import config from "./../../config";
 
-// Page at /services/123
+const searchClient = algoliasearch(
+  config.ALGOLIA_APPLICATION_ID,
+  config.ALGOLIA_READ_ONLY_API_KEY
+);
+
+const INDEX_NAME = `${config.ALGOLIA_INDEX_PREFIX}_services_search`;
+
+// NOTE: `serviceFallback` and `setServiceFallback` is a hack to fetch data from
+// Algolia rather than the Shelter Tech API. It's nott known why some data is
+// not in sync between ST's API and their Algolia instance.
+//
+// DECISION: Manage the fetched service or fallback service result separately.
+// There may be a better way to write the JSX or conditional logic below. Let's
+// tackle that post MVP.
+//
+// As a workaround we've decided to implement a partial view of the Service
+// information with a warning to verify the validity of the information
+// themselves.
 export const ServiceListingPage = () => {
   const { id } = useParams<{ id: string }>();
   const [service, setService] = useState<Service | null>(null);
+  const [serviceFallback, setServiceFallback] = useState<Service | null>(null);
   const [error, setError] = useState<FetchServiceError>();
   const details = useMemo(
     () => (service ? generateServiceDetails(service) : []),
     [service]
   );
-  const { search } = useLocation();
+
+  const { search, pathname } = useLocation();
   const searchState = useMemo(() => qs.parse(search.slice(1)), [search]);
   const { visitDeactivated } = searchState;
 
   useEffect(() => window.scrollTo(0, 0), []);
 
   useEffect(() => {
-    fetchService(id).then((s) => {
-      if ("message" in s) {
-        setService(null);
+    const fetchServiceOrFallback = async () => {
+      try {
+        const response = await fetchService(id);
 
-        setError(s);
-      } else {
-        setService(s);
+        // We need to check the contents of the response since `fetchService`
+        // does not throw. TODO: reconsider this design because processing a
+        // thrown error requires less knowledge of the response type.
+        if ("message" in response) {
+          try {
+            // CAVEAT: Hopefully this does not change!
+            const serviceObjectID = `service_${pathname.split("/")[2]}`;
+            const service = (await searchClient.getObject({
+              indexName: INDEX_NAME,
+              objectID: serviceObjectID,
+            })) as unknown as Service;
+
+            setServiceFallback(service);
+            setService(null);
+          } catch (error) {
+            setService(null);
+            setError(response);
+          }
+        } else {
+          setService(response);
+        }
+      } catch (error) {
+        setError(error as FetchServiceError);
       }
-    });
-  }, [id]);
+    };
+
+    fetchServiceOrFallback();
+  }, [id, pathname]);
+
+  // NOTE:
+  if (serviceFallback) {
+    const formattedLongDescription = serviceFallback.long_description
+      ? removeAsterisksAndHashes(serviceFallback.long_description)
+      : undefined;
+    return (
+      <ListingPageWrapper
+        title="error"
+        description=""
+        sidebarActions={[]}
+        onClickAction={() => "noop"}
+      >
+        <ListingPageHeader
+          title={serviceFallback.name}
+          dataCy="service-page-title"
+        >
+          <div
+            style={{
+              background: "LightYellow",
+              padding: "1em",
+            }}
+          >
+            <strong>
+              {" "}
+              ℹ️ The information on this page is incomplete. Please contact the
+              service provider below to confirm the provider is still active.{" "}
+            </strong>
+          </div>
+        </ListingPageHeader>
+
+        <ListingInfoSection title="About" data-cy="service-about-section">
+          <ReactMarkdown className="rendered-markdown" linkTarget="_blank">
+            {formattedLongDescription || ""}
+          </ReactMarkdown>
+        </ListingInfoSection>
+        <ListingInfoSection title="Contact" data-cy="service-contact-section">
+          <ListingInfoTable
+            rows={[serviceFallback]}
+            rowRenderer={(srv) => <ContactInfoTableRows service={srv} />}
+          />
+        </ListingInfoSection>
+      </ListingPageWrapper>
+    );
+  }
 
   if (error) {
     return (


### PR DESCRIPTION
## Description
🎟️  [As a person searching for  Services, when I click on search result and the data is not available in the Shelter Tech API, I should see a partial detail view with a call to action](https://www.notion.so/exygy/As-a-person-searching-for-Services-when-I-click-on-search-result-and-the-data-is-not-available-in--1133433f03d080dd9dccdb09b0cc4a18?pvs=4)

## Demo
### When data is available per normal
- http://localhost:8080/services/999
![image](https://github.com/user-attachments/assets/9ed9b1f3-4504-4493-a7d9-9e3249c4e9d3)

### When data is missing from API 
- http://localhost:8080/services/4269
![image](https://github.com/user-attachments/assets/e9b4bfb8-47e1-4301-b938-f9ed729a7a39)

### When there is an error processing the response from the ST API 
- http://localhost:8080/services/bad_bad_bad
- For example, if they change the structure of the JSON in their API responses.

![image](https://github.com/user-attachments/assets/63b9885a-f7b9-45e6-9724-233dc2e4a62d)