### PR TITLE
Change Children's Care to Childcare category

### DIFF
--- a/app/pages/constants.ts
+++ b/app/pages/constants.ts
@@ -38,10 +38,10 @@ export const CATEGORIES: Readonly<ServiceCategory[]> = [
     },
   },
   {
-    algoliaCategoryName: "Children's Care",
-    id: "357",
-    name: "Children's Care",
-    slug: "childrens-care",
+    algoliaCategoryName: "Childcare",
+    id: "102",
+    name: "Childcare",
+    slug: "childcare",
     steps: ["subcategories", "results"],
     subcategorySubheading: defaultSubheading,
     icon: {


### PR DESCRIPTION
🎫 : [Change “Children’s Care” to “Childcare”](https://www.notion.so/exygy/Change-Children-s-Care-to-Childcare-1163433f03d08027be50f9c7445511b5?pvs=4)

This PR closes OUR415-303:
- Edits "Children's Care" language to "Childcare"
- Updates the categoryId to use Childcare category instead of Children's Care
- Updates the slug of the category page to be `/childcare/results`
- Edits the Strapi Header dropdown name and slug values 