### PR TITLE
[OUR415-287] Fixes pagination reset upon user interactions with map

### DIFF
--- a/app/components/search/SearchMap/SearchMap.tsx
+++ b/app/components/search/SearchMap/SearchMap.tsx
@@ -13,14 +13,18 @@ import {
 import "./SearchMap.scss";
 import { TransformedSearchHit } from "../../../models";
 import config from "../../../config";
+import { SearchMapActions } from "components/search/SearchResults/SearchResults";
 
+interface SearchMapProps {
+  hits: TransformedSearchHit[];
+  mobileMapIsCollapsed: boolean;
+  handleSearchMapAction: (searchMapAction: SearchMapActions) => void;
+}
 export const SearchMap = ({
   hits,
   mobileMapIsCollapsed,
-}: {
-  hits: TransformedSearchHit[];
-  mobileMapIsCollapsed: boolean;
-}) => {
+  handleSearchMapAction,
+}: SearchMapProps) => {
   const [googleMapObject, setMapObject] = useState<google.maps.Map | null>(
     null
   );
@@ -32,6 +36,7 @@ export const SearchMap = ({
     if (center?.lat() && center?.lng()) {
       setAroundLatLng(`${center.lat()}, ${center.lng()}`);
     }
+    handleSearchMapAction(SearchMapActions.SearchThisArea);
   }
 
   const aroundLatLngToMapCenter = {

--- a/app/components/search/SearchResults/SearchResults.tsx
+++ b/app/components/search/SearchResults/SearchResults.tsx
@@ -6,7 +6,11 @@ import {
   TransformedSearchHit,
   transformSearchResults,
 } from "models/SearchHits";
-import { useInstantSearch, useSearchBox } from "react-instantsearch";
+import {
+  useInstantSearch,
+  usePagination,
+  useSearchBox,
+} from "react-instantsearch";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import algoliasearchHelper from "algoliasearch-helper";
 import styles from "./SearchResults.module.scss";
@@ -14,21 +18,20 @@ import ClearSearchButton from "../Refinements/ClearSearchButton";
 import { Loader } from "components/ui";
 import ResultsPagination from "components/search/Pagination/ResultsPagination";
 
+export enum SearchMapActions {
+  SearchThisArea,
+}
+
 const SearchResults = ({
   mobileMapIsCollapsed,
 }: {
   mobileMapIsCollapsed: boolean;
 }) => {
+  const { refine: refinePagination } = usePagination();
   const {
+    // Results type is algoliasearchHelper.SearchResults<SearchHit>
     results: searchResults,
     status,
-  }: // uiState: { query },
-  {
-    results: algoliasearchHelper.SearchResults<SearchHit>;
-    status: "idle" | "loading" | "stalled" | "error";
-    // uiState: Partial<{
-    //   query: string;
-    // }>;
   } = useInstantSearch();
   const { query } = useSearchBox();
 
@@ -63,6 +66,13 @@ const SearchResults = ({
       </div>
     );
   };
+
+  function handleAction(searchMapAction: SearchMapActions) {
+    switch (searchMapAction) {
+      case SearchMapActions.SearchThisArea:
+        return refinePagination(0);
+    }
+  }
 
   return (
     <div className={styles.searchResultsAndMapContainer}>
@@ -99,6 +109,7 @@ const SearchResults = ({
       <SearchMap
         hits={searchMapHitData.hits}
         mobileMapIsCollapsed={mobileMapIsCollapsed}
+        handleSearchMapAction={handleAction}
       />
     </div>
   );

--- a/app/components/search/SearchResults/SearchResults.tsx
+++ b/app/components/search/SearchResults/SearchResults.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from "react";
 import { SearchMap } from "components/search/SearchMap/SearchMap";
 import { SearchResult } from "components/search/SearchResults/SearchResult";
 import {
-  SearchHit,
   TransformedSearchHit,
   transformSearchResults,
 } from "models/SearchHits";
@@ -11,8 +10,6 @@ import {
   usePagination,
   useSearchBox,
 } from "react-instantsearch";
-// eslint-disable-next-line import/no-extraneous-dependencies
-import algoliasearchHelper from "algoliasearch-helper";
 import styles from "./SearchResults.module.scss";
 import ClearSearchButton from "../Refinements/ClearSearchButton";
 import { Loader } from "components/ui";

--- a/app/components/search/SearchResults/SearchResults.tsx
+++ b/app/components/search/SearchResults/SearchResults.tsx
@@ -64,12 +64,12 @@ const SearchResults = ({
     );
   };
 
-  function handleAction(searchMapAction: SearchMapActions) {
+  const handleAction = (searchMapAction: SearchMapActions) => {
     switch (searchMapAction) {
       case SearchMapActions.SearchThisArea:
         return refinePagination(0);
     }
-  }
+  };
 
   return (
     <div className={styles.searchResultsAndMapContainer}>


### PR DESCRIPTION
🎟️ [Search this Area button doesn’t reset the page number](https://www.notion.so/exygy/Search-this-Area-button-doesn-t-reset-the-page-number-1043433f03d080579759dfd9bfefebd3?pvs=4)

Fixes the resetting issue but adds a little more ceremony to lift the interaction handling for the `Search this Area` button up a component level to the `SearchResults` component. This has the benefit of decoupling the `SearchMap` component from other components and app state by letting it simply focus on emitting actions.

After:

https://github.com/user-attachments/assets/02361a41-96cf-4948-baae-fbb2d952639b

