### PR TITLE
Edit footer link label to use strapi text instead of url

### DIFF
--- a/app/components/ui/Footer/FooterLink.tsx
+++ b/app/components/ui/Footer/FooterLink.tsx
@@ -13,7 +13,7 @@ export const FooterLink = ({ link }: { link: LinkModel }) => {
 
   return (
     <a href={link.url} target="_blank" rel="noopener noreferrer">
-      {link.url}
+      {link.text}
     </a>
   );
 };


### PR DESCRIPTION
This, along with content changes in Strapi, resolve [Footer bug](https://www.notion.so/exygy/Footer-bug-1063433f03d080e89301d888dc2c15fe?pvs=24)