### PR TITLE
quick title improvement for service detail page

### DIFF
--- a/app/pages/ServiceDetailPage/ServiceDetailPage.tsx
+++ b/app/pages/ServiceDetailPage/ServiceDetailPage.tsx
@@ -103,7 +103,7 @@ export const ServiceDetailPage = () => {
       : undefined;
     return (
       <DetailPageWrapper
-        title="error"
+        title={`Our415 - ${serviceFallback.name}`}
         description=""
         sidebarActions={[]}
         onClickAction={() => "noop"}
@@ -146,7 +146,7 @@ export const ServiceDetailPage = () => {
   if (error) {
     return (
       <DetailPageWrapper
-        title="error"
+        title="Our415 - Page Error"
         description=""
         sidebarActions={[]}
         onClickAction={() => "noop"}
@@ -189,7 +189,7 @@ export const ServiceDetailPage = () => {
 
   return (
     <DetailPageWrapper
-      title={service.name}
+      title={`Our415 - ${service.name}`}
       description={service.long_description || ""}
       sidebarActions={sidebarActions}
       onClickAction={onClickAction}


### PR DESCRIPTION
Quick improvement I found while looking at [Some service listings fail to open detail pages, displaying API response errors.](https://www.notion.so/exygy/Some-service-listings-fail-to-open-detail-pages-displaying-API-response-errors-1063433f03d080c79e57d29ba6c242d7?pvs=24)

NOTE: That ticket seems to be handled already but the browser tab title was still "error" so I fixed that here 