### PR TITLE
[Our415-45] Page Not Found page and component 

### DIFF
--- a/app/Router.tsx
+++ b/app/Router.tsx
@@ -12,6 +12,7 @@ import { PageHeader } from "components/ui/Navigation/PageHeader";
 import { BackButton } from "components/ui/BackButton";
 import { SearchHeaderSection } from "components/SearchAndBrowse/Header/SearchHeaderSection";
 import { SearchResultsPage } from "pages/SearchResultsPage/SearchResultsPage";
+import { PageNotFoundPage } from "pages/PageNotFoundPage/PageNotFoundPage";
 
 export const Router = () => {
   return (
@@ -60,6 +61,7 @@ export const Router = () => {
       />
       <Route path="/terms-of-service" element={<TermsOfServicePage />} />
       <Route path="/:categorySlug/results" element={<BrowseResultsPage />} />
+      <Route path="*" element={<PageNotFoundPage />} />
     </Routes>
   );
 };

--- a/app/components/ui/PageNotFound.module.scss
+++ b/app/components/ui/PageNotFound.module.scss
@@ -1,0 +1,11 @@
+@import "../../styles/utils/_helpers.scss";
+
+h1 {
+  color: $text-primary;
+}
+
+.description {
+  color: $text-primary;
+  margin-top: $general-spacing-md;
+  margin-bottom: $general-spacing-xl;
+}

--- a/app/components/ui/PageNotFound.tsx
+++ b/app/components/ui/PageNotFound.tsx
@@ -10,7 +10,9 @@ const PageNotFound = () => {
         We’re sorry, but the page you’re looking for can’t be found. The URL may
         be misspelled or the page you’re looking for is no longer available.
       </p>
-      <Button href="/">Go to the homepage →</Button>
+      <Button href="/" arrowVariant="after">
+        Go to the homepage
+      </Button>
     </div>
   );
 };

--- a/app/components/ui/PageNotFound.tsx
+++ b/app/components/ui/PageNotFound.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Button } from "./inline/Button/Button";
+import styles from "./PageNotFound.module.scss";
+
+const PageNotFound = () => {
+  return (
+    <div>
+      <h1>Page not found</h1>
+      <p className={styles.description}>
+        We’re sorry, but the page you’re looking for can’t be found. The URL may
+        be misspelled or the page you’re looking for is no longer available.
+      </p>
+      <Button href="/">Go to the homepage →</Button>
+    </div>
+  );
+};
+
+export default PageNotFound;

--- a/app/pages/OrganizationDetailPage.tsx
+++ b/app/pages/OrganizationDetailPage.tsx
@@ -45,10 +45,6 @@ export const OrganizationDetailPage = () => {
       try {
         const org = await fetchOrganization(organizationListingId as string);
 
-        if ("message" in org) {
-          throw new Error();
-        }
-
         setOrg(org);
         setError(null);
       } catch (err) {

--- a/app/pages/OrganizationDetailPage.tsx
+++ b/app/pages/OrganizationDetailPage.tsx
@@ -17,8 +17,8 @@ import {
   ServiceCard,
   WebsiteRenderer,
 } from "../components/DetailPage";
+import PageNotFound from "components/ui/PageNotFound";
 import { Loader } from "components/ui/Loader";
-
 import {
   fetchOrganization,
   getOrganizationActions,
@@ -35,18 +35,62 @@ export const OrganizationDetailPage = () => {
   const searchState = useMemo(() => qs.parse(search.slice(1)), [search]);
   const { visitDeactivated } = searchState;
 
-  useEffect(() => window.scrollTo(0, 0), []);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
+  useEffect(() => window.scrollTo(0, 0), []);
   useEffect(() => {
-    fetchOrganization(organizationListingId as string).then((o) => setOrg(o));
-    // TODO Handle Errors
+    const fetchOrganizationWithErrorHandling = async () => {
+      setIsLoading(true);
+      try {
+        const org = await fetchOrganization(organizationListingId as string);
+
+        if ("message" in org) {
+          throw new Error();
+        }
+
+        setOrg(org);
+        setError(null);
+      } catch (err) {
+        setError(err as Error);
+        setOrg(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchOrganizationWithErrorHandling();
   }, [organizationListingId]);
 
-  if (!org) {
+  if (isLoading) {
     return <Loader />;
   }
+
+  if (error || !org) {
+    return (
+      <DetailPageWrapper
+        title={`Our415`}
+        description=""
+        sidebarActions={[]}
+        onClickAction={() => "noop"}
+      >
+        <PageNotFound />
+      </DetailPageWrapper>
+    );
+  }
+
+  // When is org.status inactive?
   if (org.status === "inactive" && !visitDeactivated) {
-    return <Navigate to="/" />;
+    return (
+      <DetailPageWrapper
+        title={`Our415`}
+        description=""
+        sidebarActions={[]}
+        onClickAction={() => "noop"}
+      >
+        <PageNotFound />
+      </DetailPageWrapper>
+    );
   }
 
   const orgLocations = getOrganizationLocations(org);

--- a/app/pages/OrganizationDetailPage.tsx
+++ b/app/pages/OrganizationDetailPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
-import { useParams, Navigate, useLocation } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 import qs from "qs";
 import { DetailInfoSection } from "components/ui/Cards/DetailInfoSection";
 import { removeAsterisksAndHashes } from "utils/strings";

--- a/app/pages/PageNotFoundPage/PageNotFoundPage.module.scss
+++ b/app/pages/PageNotFoundPage/PageNotFoundPage.module.scss
@@ -1,0 +1,16 @@
+@import "../../styles/utils/_helpers.scss";
+
+.container {
+  background: $color-grey1;
+  padding: $section-padding-desktop-vertical $general-spacing-md;
+  background: $color-white;
+
+  @include r_max($break-tablet-s) {
+    padding: $section-padding-mobile-vertical $general-spacing-md;
+  }
+}
+
+.inner {
+  max-width: 42rem;
+  margin: auto;
+}

--- a/app/pages/PageNotFoundPage/PageNotFoundPage.tsx
+++ b/app/pages/PageNotFoundPage/PageNotFoundPage.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import PageNotFound from "components/ui/PageNotFound";
+import styles from "./PageNotFoundPage.module.scss";
+
+export const PageNotFoundPage = () => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.inner}>
+        <PageNotFound />
+      </div>
+    </div>
+  );
+};

--- a/app/pages/ServiceDetailPage/ServiceDetailPage.tsx
+++ b/app/pages/ServiceDetailPage/ServiceDetailPage.tsx
@@ -28,6 +28,7 @@ import {
 import styles from "./ServiceDetailPage.module.scss";
 import { searchClient } from "@algolia/client-search";
 import config from "../../config";
+import PageNotFound from "components/ui/PageNotFound";
 
 const client = searchClient(
   config.ALGOLIA_APPLICATION_ID,
@@ -151,7 +152,7 @@ export const ServiceDetailPage = () => {
         sidebarActions={[]}
         onClickAction={() => "noop"}
       >
-        {error.message}
+        <PageNotFound />
       </DetailPageWrapper>
     );
   }
@@ -160,7 +161,7 @@ export const ServiceDetailPage = () => {
     return <Loader />;
   }
   if (service.status === "inactive" && !visitDeactivated) {
-    return <Navigate to="/" />;
+    return <PageNotFound />;
   }
 
   const { resource, recurringSchedule } = service;

--- a/app/pages/ServiceDetailPage/ServiceDetailPage.tsx
+++ b/app/pages/ServiceDetailPage/ServiceDetailPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
-import { useParams, useLocation, Navigate } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 import qs from "qs";
 import {
   ActionBarMobile,


### PR DESCRIPTION
🎫: [404 page / page not found](https://www.notion.so/exygy/404-page-page-not-found-13e3433f03d08026b9f2ca1899cb687c?pvs=24)

This creates the `PageNotFound` component and page per mockup

Adds component to:
- `ServiceDetailPage`
- `OrganizationDetailPage`
NOTE: This keeps the back page and also makes it easy to pass in different messages as props if we decide to do so in the future

Adds `PageNotFoundPage` to `Router` as a catch-all 

### Screenshots

**Firefox 132.0.2 (aarch64)**
![Screen Shot 2024-11-19 at 15 07 21-fullpage](https://github.com/user-attachments/assets/7a959fde-d584-4fa4-bd51-c9219fc06a57)
