### PR TITLE
Mobile menu cutoff bug fix 

### DIFF
--- a/app/components/ui/Navigation/MobileNavigation.module.scss
+++ b/app/components/ui/Navigation/MobileNavigation.module.scss
@@ -159,3 +159,11 @@
     top: $header-mobile-height;
   }
 }
+
+@include r_max($break-mobile) {
+  .mobileNavigationContainer {
+    right: auto;
+    left: 0;
+    width: 100vw;
+  }
+}

--- a/app/styles/utils/_layoututils.scss
+++ b/app/styles/utils/_layoututils.scss
@@ -4,6 +4,7 @@
 @import "_spacing";
 
 $font-size: 16px;
+$break-mobile: 450px;
 $break-tablet-s: 767px;
 $break-tablet-p: 960px;
 $break-tablet-l: 1184px;


### PR DESCRIPTION
🎫: [Mobile menu cut off](https://www.notion.so/exygy/Mobile-menu-cut-off-1443433f03d0800c88e6dfc1d11716ba?pvs=4)

This PR styles the mobile menu on mobile sized screens so that it is 100vw wide.

Before:
![image](https://github.com/user-attachments/assets/5f76b906-7578-4d14-a68c-ffa1b4157f50)

After:
![image](https://github.com/user-attachments/assets/69838f60-63e0-4268-a95b-40980d6c9c94)
