### PR TITLE
[Our415-93] Move google translate into TopBar and hide elsewhere

### DIFF
--- a/app/components/ui/Navigation/MobileNavigation.tsx
+++ b/app/components/ui/Navigation/MobileNavigation.tsx
@@ -167,9 +167,9 @@ export const MobileNavigation = ({ menuData }: MobileNavigationProps) => {
             );
           })}
 
-          <div className={mobileNavigationStyles.mobileNavigationMenuTranslate}>
+          {/* <div className={mobileNavigationStyles.mobileNavigationMenuTranslate}>
             <GoogleTranslate />
-          </div>
+          </div> */}
         </div>
       )}
     </>

--- a/app/components/ui/Navigation/MobileNavigation.tsx
+++ b/app/components/ui/Navigation/MobileNavigation.tsx
@@ -6,7 +6,6 @@ import {
   NavigationMenu,
   Link as LinkModel,
 } from "models/Strapi";
-import { GoogleTranslate } from "../GoogleTranslate";
 import { Button } from "components/ui/inline/Button/Button";
 import useClickOutside from "hooks/MenuHooks";
 
@@ -166,10 +165,6 @@ export const MobileNavigation = ({ menuData }: MobileNavigationProps) => {
               </li>
             );
           })}
-
-          {/* <div className={mobileNavigationStyles.mobileNavigationMenuTranslate}>
-            <GoogleTranslate />
-          </div> */}
         </div>
       )}
     </>

--- a/app/components/ui/Navigation/Navigation.module.scss
+++ b/app/components/ui/Navigation/Navigation.module.scss
@@ -63,14 +63,6 @@
   flex-direction: row;
   align-items: center;
 
-  > :nth-last-child(2) {
-    // Adds separator
-    border-right: 1px solid black;
-    padding-right: $spacing-4;
-    margin-right: $spacing-6;
-  }
-  // margin-right: $spacing-6;
-
   > * {
     font-weight: 600;
   }

--- a/app/components/ui/Navigation/Navigation.tsx
+++ b/app/components/ui/Navigation/Navigation.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import styles from "components/ui/Navigation/Navigation.module.scss";
-import { GoogleTranslate } from "components/ui/GoogleTranslate";
 import desktopNavigationStyles from "components/ui/Navigation/DesktopNavigation.module.scss";
 import DropdownMenu from "components/ui/Navigation/DropdownMenu";
 import { MobileNavigation } from "components/ui/Navigation/MobileNavigation";
@@ -109,9 +108,6 @@ export const Navigation = () => {
                   </Link>
                 );
               })}
-              {/* <div className={styles.navigationMenuTranslate}>
-                <GoogleTranslate />
-              </div> */}
             </div>
           </div>
         </nav>

--- a/app/components/ui/Navigation/Navigation.tsx
+++ b/app/components/ui/Navigation/Navigation.tsx
@@ -15,6 +15,7 @@ import { useNavigationData } from "hooks/StrapiAPI";
 import { Router } from "../../../Router";
 import NavigationFocusReset from "./NavigationFocusReset";
 import SkipButton from "./SkipButton";
+import TopBanner from "./TopBanner";
 import { SiteSearchInput } from "components/ui/SiteSearchInput";
 import { InstantSearch } from "react-instantsearch-core";
 import { liteClient } from "algoliasearch/lite";
@@ -66,6 +67,7 @@ export const Navigation = () => {
     >
       <NavigationFocusReset />
       <SkipButton />
+      <TopBanner />
       <div>
         <nav className={styles.siteNav}>
           <div className={styles.primaryRow}>
@@ -107,9 +109,9 @@ export const Navigation = () => {
                   </Link>
                 );
               })}
-              <div className={styles.navigationMenuTranslate}>
+              {/* <div className={styles.navigationMenuTranslate}>
                 <GoogleTranslate />
-              </div>
+              </div> */}
             </div>
           </div>
         </nav>

--- a/app/components/ui/Navigation/TopBanner.module.scss
+++ b/app/components/ui/Navigation/TopBanner.module.scss
@@ -1,0 +1,21 @@
+@import "../../../styles/utils/_helpers.scss";
+@import "../../../styles/utils/_colors.scss";
+
+.topBanner {
+  //   @include r_min($break-tablet-s) {
+  //     display: none;
+  //   }
+
+  width: 100vw;
+  background: $gray-50;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  padding: 0 $general-spacing-md;
+
+  justify-content: flex-end;
+
+  .goog-te-gadget {
+    display: flex !important;
+  }
+}

--- a/app/components/ui/Navigation/TopBanner.module.scss
+++ b/app/components/ui/Navigation/TopBanner.module.scss
@@ -2,10 +2,6 @@
 @import "../../../styles/utils/_colors.scss";
 
 .topBanner {
-  //   @include r_min($break-tablet-s) {
-  //     display: none;
-  //   }
-
   width: 100vw;
   background: $gray-50;
   height: 60px;

--- a/app/components/ui/Navigation/TopBanner.tsx
+++ b/app/components/ui/Navigation/TopBanner.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { GoogleTranslate } from "../GoogleTranslate";
+import styles from "./TopBanner.module.scss";
+
+const TopBanner = () => {
+  return (
+    <div className={styles.topBanner}>
+      <GoogleTranslate />
+    </div>
+  );
+};
+
+export default TopBanner;


### PR DESCRIPTION
🎫: [Explore moving language selector out of mobile menu](https://www.notion.so/exygy/Explore-moving-language-selector-out-of-mobile-menu-1443433f03d080c88680cc4485e4357d?pvs=24)

This PR: 
- Moves the Google Translate widget out of the desktop navbar and the mobile dropdown and into its own TopBanner component, used for both desktop and mobile
- Navbar is meant to be sticky, while TopBanner is not, so as user scrolls the banner disappears leaving them with more screen real estate to see actionable content

NOTE: This is not meant to be a final iteration but something we can test on both mobile and desktop on the staging URL that design can then QA / request changes.