### PR TITLE
[OUR415-BUG-29] Fixes `Distance` filter by setting `aroundLatLng` (user's map location) on site load

### DIFF
--- a/app/App.test.tsx
+++ b/app/App.test.tsx
@@ -24,11 +24,9 @@ describe("<App />", () => {
     });
   });
 
-  // Generally we want to avoid testing prop passing directly, and instead
-  // figure out a test that reflects real user behavior to confirm the props.
-  // Let's use this for the time being until we have a better way to test these
-  // props being set on page load. It may make sense to move the data fetching
-  // and setting to a hook we can test independently.
+  // Until we can design a test that reflects real user behavior, lets test that
+  // the default `AppProvider` props are created and set correctly by mocking
+  // the component.
   it("sends the correct props to the <AppProvider />", async () => {
     const expectedArg1 = expect.objectContaining({
       aroundLatLng: "37.7749,-122.4194",

--- a/app/App.test.tsx
+++ b/app/App.test.tsx
@@ -28,14 +28,16 @@ describe("<App />", () => {
   // the default `AppProvider` props are created and set correctly by mocking
   // the component.
   it("sends the correct props to the <AppProvider />", async () => {
-    const expectedArg1 = expect.objectContaining({
+    const expectedProps = expect.objectContaining({
       aroundLatLng: "37.7749,-122.4194",
       userLocation: { lat: 37.7749, lng: -122.4194 },
       aroundUserLocationRadius: "all",
       setAroundRadius: expect.any(Function),
       setAroundLatLng: expect.any(Function),
     });
-    const expectedArg2 = {};
+
+    // https://stackoverflow.com/questions/56879095/what-is-the-second-parameter-for-in-a-react-functional-component
+    const legacyRefOrContextArgument = expect.anything();
 
     render(
       <HelmetProvider>
@@ -45,7 +47,10 @@ describe("<App />", () => {
     );
 
     await waitFor(() => {
-      expect(AppProvider).toHaveBeenCalledWith(expectedArg1, expectedArg2);
+      expect(AppProvider).toHaveBeenCalledWith(
+        expectedProps,
+        legacyRefOrContextArgument
+      );
     });
   });
 });

--- a/app/App.test.tsx
+++ b/app/App.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { App } from "App";
+import { HelmetProvider } from "react-helmet-async";
+import { AppProvider } from "utils";
+
+jest.mock("instantsearch.js/es/lib/routers", () => ({}));
+jest.mock("./utils/useAppContext", () => ({
+  AppProvider: jest.fn(),
+}));
+
+describe("<App />", () => {
+  it("renders", async () => {
+    render(
+      <HelmetProvider>
+        <App />
+      </HelmetProvider>,
+      { wrapper: BrowserRouter }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("app-container")).toBeInTheDocument();
+    });
+  });
+
+  // Generally we want to avoid testing prop passing directly, and instead
+  // figure out a test that reflects real user behavior to confirm the props.
+  // Let's use this for the time being until we have a better way to test these
+  // props being set on page load. It may make sense to move the data fetching
+  // and setting to a hook we can test independently.
+  it("sends the correct props to the <AppProvider />", async () => {
+    const expectedArg1 = expect.objectContaining({
+      aroundLatLng: "37.7749,-122.4194",
+      userLocation: { lat: 37.7749, lng: -122.4194 },
+      aroundUserLocationRadius: "all",
+      setAroundRadius: expect.any(Function),
+      setAroundLatLng: expect.any(Function),
+    });
+    const expectedArg2 = {};
+
+    render(
+      <HelmetProvider>
+        <App />
+      </HelmetProvider>,
+      { wrapper: BrowserRouter }
+    );
+
+    await waitFor(() => {
+      expect(AppProvider).toHaveBeenCalledWith(expectedArg1, expectedArg2);
+    });
+  });
+});

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -10,6 +10,7 @@ import {
   getLocation,
   websiteConfig,
   AppProvider,
+  useAppContextUpdater,
 } from "./utils";
 import { Footer } from "components/ui/Footer/Footer";
 import { Navigation } from "components/ui/Navigation/Navigation";
@@ -18,6 +19,7 @@ import { Loader } from "components/ui/Loader";
 import MetaImage from "./assets/img/Our415_OG.png";
 import styles from "./App.module.scss";
 import config from "./config";
+import { AroundRadius } from "algoliasearch";
 
 const { siteUrl, title } = websiteConfig;
 export const OUTER_CONTAINER_ID = "outer-container";
@@ -25,10 +27,15 @@ export const OUTER_CONTAINER_ID = "outer-container";
 export const App = () => {
   const location = useLocation();
   const [userLocation, setUserLocation] = useState<GeoCoordinates | null>(null);
+  const [aroundLatLng, setAroundLatLng] = useState<string>("");
+  const [aroundUserLocationRadius, setAroundRadius] = useState<AroundRadius>(
+    "all" as const
+  );
 
   useEffect(() => {
     getLocation().then((loc) => {
       setUserLocation(loc);
+      setAroundLatLng(`${loc.lat},${loc.lng}`);
     });
 
     if (config.GOOGLE_ANALYTICS_GA4_ID) {
@@ -47,15 +54,23 @@ export const App = () => {
         page,
       });
     }, 500);
-  }, [location]);
+  }, [location, setAroundLatLng]);
 
   if (!userLocation) {
     return <Loader />;
   }
 
+  const props = {
+    userLocation,
+    aroundLatLng,
+    setAroundLatLng,
+    aroundUserLocationRadius,
+    setAroundRadius,
+  };
+
   return (
     <div id={OUTER_CONTAINER_ID} className={styles.outerContainer}>
-      <AppProvider userLocation={userLocation}>
+      <AppProvider {...props}>
         <Helmet>
           <title>{title}</title>
           <meta property="og:url" content={siteUrl} />

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -10,7 +10,6 @@ import {
   getLocation,
   websiteConfig,
   AppProvider,
-  useAppContextUpdater,
 } from "./utils";
 import { Footer } from "components/ui/Footer/Footer";
 import { Navigation } from "components/ui/Navigation/Navigation";

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -56,6 +56,8 @@ export const App = () => {
   }, [location, setAroundLatLng]);
 
   if (!userLocation) {
+    console.log("🪵 ~ App ~ userLocation:", userLocation);
+
     return <Loader />;
   }
 
@@ -66,9 +68,14 @@ export const App = () => {
     aroundUserLocationRadius,
     setAroundRadius,
   };
+  console.log("🪵 ~ App ~ props:", props);
 
   return (
-    <div id={OUTER_CONTAINER_ID} className={styles.outerContainer}>
+    <div
+      id={OUTER_CONTAINER_ID}
+      className={styles.outerContainer}
+      data-testid={"app-container"}
+    >
       <AppProvider {...props}>
         <Helmet>
           <title>{title}</title>

--- a/app/pages/BrowseResultsPage/BrowseResultsPage.tsx
+++ b/app/pages/BrowseResultsPage/BrowseResultsPage.tsx
@@ -37,6 +37,7 @@ export const BrowseResultsPage = () => {
     null
   );
   const eligibilities = useEligibilitiesForCategory(category.id);
+  console.log("🪵 ~ BrowseResultsPage ~ eligibilities:", eligibilities);
   const subcategories = useSubcategoriesForCategory(category.id);
   const [isMapCollapsed, setIsMapCollapsed] = useState(false);
   const { userLocation } = useAppContext();

--- a/app/pages/BrowseResultsPage/BrowseResultsPage.tsx
+++ b/app/pages/BrowseResultsPage/BrowseResultsPage.tsx
@@ -37,7 +37,6 @@ export const BrowseResultsPage = () => {
     null
   );
   const eligibilities = useEligibilitiesForCategory(category.id);
-  console.log("🪵 ~ BrowseResultsPage ~ eligibilities:", eligibilities);
   const subcategories = useSubcategoriesForCategory(category.id);
   const [isMapCollapsed, setIsMapCollapsed] = useState(false);
   const { userLocation } = useAppContext();

--- a/app/pages/EventDetailPage/EventDetailPage.test.tsx
+++ b/app/pages/EventDetailPage/EventDetailPage.test.tsx
@@ -1,10 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { EventDetailPage } from "pages/EventDetailPage/EventDetailPage";
-import {
-  createFormattedEventData,
-  EVENTS_DATA,
-} from "../../../test/fixtures/EventsData";
+import { createFormattedEventData } from "../../../test/fixtures/EventsData";
 import { useEventData } from "hooks/StrapiAPI";
 import { HelmetProvider } from "react-helmet-async";
 

--- a/app/utils/useAppContext.tsx
+++ b/app/utils/useAppContext.tsx
@@ -3,7 +3,6 @@ import React, {
   useMemo,
   createContext,
   useContext,
-  useState,
   Dispatch,
   SetStateAction,
 } from "react";

--- a/app/utils/useAppContext.tsx
+++ b/app/utils/useAppContext.tsx
@@ -22,7 +22,11 @@ interface ContextUpdater {
 
 interface AppProviderProps {
   userLocation: GeoCoordinates | null;
+  aroundLatLng: string;
   children: React.ReactNode;
+  setAroundLatLng: Dispatch<SetStateAction<string>>;
+  aroundUserLocationRadius: AroundRadius;
+  setAroundRadius: Dispatch<SetStateAction<"all" | number>>;
 }
 
 export const AppContext = createContext<Context>({
@@ -33,17 +37,20 @@ export const AppContext = createContext<Context>({
 
 export const AppContextUpdater = createContext<ContextUpdater>({
   setAroundRadius: () => "all",
-  setAroundLatLng: () => "all",
+  setAroundLatLng: () => "",
 });
 
 export const useAppContext = () => useContext(AppContext);
 export const useAppContextUpdater = () => useContext(AppContextUpdater);
 
-export const AppProvider = ({ children, userLocation }: AppProviderProps) => {
-  const [aroundUserLocationRadius, setAroundRadius] = useState<AroundRadius>(
-    "all" as const
-  );
-  const [aroundLatLng, setAroundLatLng] = useState<string>("");
+export const AppProvider = ({
+  children,
+  userLocation,
+  aroundLatLng,
+  setAroundLatLng,
+  aroundUserLocationRadius,
+  setAroundRadius,
+}: AppProviderProps) => {
   // We have to use useMemo here to manage the contextValue to ensure that the user's authState
   // propagates downward after authentication. I couldn't find a way to get this to work with
   // useState. Moreover, we can't use a simple object to define contextValue, as the object would

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -68,7 +68,10 @@ const config: Config = {
 
   // A set of global variables that need to be available in all test environments
   globals: {
-    CONFIG: {},
+    CONFIG: {
+      ALGOLIA_APPLICATION_ID: "ALGOLIA_APPLICATION_ID",
+      ALGOLIA_READ_ONLY_API_KEY: "ALGOLIA_READ_ONLY_API_KEY",
+    },
   },
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,12 +1,13 @@
-###  📝 Description
+### 📝 Description
 
 ### 🍐 Paired with
 
 ### 🔗 Related links
 
-###  🛠 Changes
+### 🛠 Changes
 
 ### 🖼 Screenshots
+
 |         | before | after |
 | ------- | ------ | ----- |
 | desktop |        |       |

--- a/test/templates/Template.test.tsx
+++ b/test/templates/Template.test.tsx
@@ -5,11 +5,14 @@
  * coding from there!
  */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 
 // Normally imported from components directory
 const MyFakeComponent = ({ text }: { text: string }) => <>{text}</>;
+
+// Put any module mocks outside test blocks
+jest.mock("<my-module>", () => (<'mock implementation'>));
 
 describe("<MyFakeComponent />", () => {
   const parameters = {
@@ -21,5 +24,15 @@ describe("<MyFakeComponent />", () => {
     expect(screen.getByTestId("my-component-test-id")).toHaveTextContent(
       parameters.text
     );
+  });
+
+  it("renders with async effects", async () => {
+    render(<MyFakeComponent {...parameters} />, { wrapper: BrowserRouter });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("my-component-test-id")).toHaveTextContent(
+        parameters.text
+      );
+    });
   });
 });

--- a/test/templates/Template.test.tsx
+++ b/test/templates/Template.test.tsx
@@ -12,7 +12,7 @@ import { BrowserRouter } from "react-router-dom";
 const MyFakeComponent = ({ text }: { text: string }) => <>{text}</>;
 
 // Put any module mocks outside test blocks
-jest.mock("<my-module>", () => (<'mock implementation'>));
+// jest.mock("<my-module>", () => (<'mock implementation'>));
 
 describe("<MyFakeComponent />", () => {
   const parameters = {


### PR DESCRIPTION
###  📝 Description

This was likely broken since the big React 18 refactor. The root cause is that the user's map location -- the somewhat poorly named `aroudnLatLng` -- is never set on site/page load. It was only getting set when the user clicked the `Search this area` button on the map. This meant the distance filtering seemed to work sporadically from the user's point of view, but in most cases it simply didn't. 

### 🔗 Related links

- [🐞 Report](https://www.notion.so/exygy/Verify-that-Distance-filter-works-17e3433f03d0803aba26c8574d1683a8?pvs=4)

###  🛠 Changes
- Adds a test file for the root `<App />` component
	- Asserts basic render
	- Asserts correct props are created and passed to `<AppProvider />`, including the related location props to fix this bug

### 🖼 Screenshots

https://github.com/user-attachments/assets/f29054d2-1aa0-4bd5-8319-054d588252b1

### ✏️ Notes
- This feature likely needs more QA and automated testing. We don't seem to have a good product spec for what to expect when it's used. 
- In a divine moment of prescience, I had actually flagged this feature needing a more thorough examination a while back: https://exygy.slack.com/archives/C06T4125086/p1725492752882169