### PR TITLE
[OUR415-BUG-22] Ensures category navigation dropdown on mobile is flush right 

### DIFF
--- a/app/components/ui/Navigation/MobileNavigation.module.scss
+++ b/app/components/ui/Navigation/MobileNavigation.module.scss
@@ -5,7 +5,7 @@
   position: absolute;
   border-top: 1px solid $gray-300;
   border-bottom: 1px solid $gray-300;
-  right: $spacing-6;
+  right: 0;
   top: $header-height;
   background: $white;
   width: 400px;


### PR DESCRIPTION
###  📝 Description

🤷 Guess we missed it!

### 🔗 Related links

- [🎫 Task](https://www.notion.so/exygy/Mobile-menu-overlay-placement-1113433f03d080efa1f1c294e5c56646?pvs=4)

### 🖼 Screenshots
|         | before | after |
| ------- | ------ | ----- |
| mobile  |  ![image](https://github.com/user-attachments/assets/a1806fed-4597-4b83-8304-9676e6285a88)       |   ![image](https://github.com/user-attachments/assets/7d859f5a-bce6-49d3-9c99-f31ea603463e) |
