### PR TITLE
[OUR415-BUG-43] and a few other minor fixes

### DIFF
--- a/app/components/ui/Cards/EventCard.module.scss
+++ b/app/components/ui/Cards/EventCard.module.scss
@@ -30,7 +30,7 @@
   }
 
   .cardImage {
-    width: 100%;
+    width: 200px;
     object-fit: cover;
 
     // Sizes and positions empty image icon

--- a/app/components/ui/TwoColumnContentSection/SingleColumnContentSection.module.scss
+++ b/app/components/ui/TwoColumnContentSection/SingleColumnContentSection.module.scss
@@ -2,7 +2,7 @@
 @import "../../../styles/utils/_layoututils.scss";
 
 .singleColumnContentSectionContainer {
-  padding: 2rem;
+  padding: $general-spacing-xl;
   display: flex;
   justify-content: center;
 }

--- a/app/pages/constants.ts
+++ b/app/pages/constants.ts
@@ -39,7 +39,7 @@ export const CATEGORIES: Readonly<ServiceCategory[]> = [
   },
   {
     algoliaCategoryName: "Childcare",
-    id: "102",
+    id: "357",
     name: "Childcare",
     slug: "childcare",
     steps: ["subcategories", "results"],

--- a/app/utils/formatEventDate.test.ts
+++ b/app/utils/formatEventDate.test.ts
@@ -1,0 +1,11 @@
+import formatEventDate from "./formatEventDate";
+
+describe("formatEventDate", () => {
+  it("from iso date to human readable localized date", () => {
+    const isoDate = "2024-1-30";
+    const actual = formatEventDate(isoDate);
+    const expected = "January 30, 2024";
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/app/utils/formatEventDate.ts
+++ b/app/utils/formatEventDate.ts
@@ -2,7 +2,7 @@ export default function formatEventDate(date: string) {
   // The Date constructor is inconsistent depending on the date formatting. For example, it will parse dates formatted
   // as yyyy-mm-dd as UTC. With slashes it will be parsed as "local time" -- not based on actual locale timezone, but
   // perceived relative local time.
-  const toFormat = date.replace("-", "/");
+  const toFormat = date.replaceAll("-", "/");
   return new Date(toFormat).toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",

--- a/app/utils/formatEventTime.test.ts
+++ b/app/utils/formatEventTime.test.ts
@@ -1,0 +1,11 @@
+import formatEventTime from "./formatEventTime";
+
+describe("formatEventTime", () => {
+  it("from iso date to human readable localized date", () => {
+    const isoTime = "2025-01-29 06:00:00";
+    const actual = formatEventTime(isoTime);
+    const expected = "6:00 AM";
+
+    expect(actual).toBe(expected);
+  });
+});


### PR DESCRIPTION
### 📝 Description
- Fixes homepage event card width (not sure why this regressed for the flex row layout)
- Switches the top level category for childcare for debugging https://www.notion.so/Why-is-Childcare-top-level-category-pulling-in-eligibilities-into-sidebar-17e3433f03d08087b45cf3c8225a8679?pvs=4
- Fixes date bug that _only_ was showing up in Safari. Chrome/Firefox very forgiving of strange date formats like `2025/01-29`