### PR TITLE
Back button mobile width

### DIFF
--- a/app/components/ui/BackButton.tsx
+++ b/app/components/ui/BackButton.tsx
@@ -27,6 +27,7 @@ export const BackButton = ({
         onClick={backDestination}
         variant="linkWhite"
         arrowVariant="before"
+        mobileFullWidth={false}
       >
         {children}
       </Button>


### PR DESCRIPTION
[Need to click “Back to Services” button twice on service page for it to work properly](https://www.notion.so/exygy/Need-to-click-Back-to-Services-button-twice-on-service-page-for-it-to-work-properly-1823433f03d08005a903cabaf65dde6e?pvs=4)

I submitted this bug but i can no longer repro. Did change the mobile width to not be full width for better UX / design