### PR TITLE
[Our415-Bug-42] Fix scroll issue

### DIFF
--- a/app/components/DetailPage/DetailPageWrapper.tsx
+++ b/app/components/DetailPage/DetailPageWrapper.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Helmet } from "react-helmet-async";
 import { ActionSidebar } from "components/DetailPage";
 import styles from "./DetailPageWrapper.module.scss";
@@ -18,24 +18,27 @@ const DetailPageWrapper = ({
   children,
   sidebarActions,
   onClickAction,
-}: DetailPageWrapperProps) => (
-  <div className={styles[`detail-wrapper`]}>
-    <Helmet>
-      <title>{title}</title>
-      <meta name="description" content={description} />
-    </Helmet>
-    <article className={styles.detail} id="resource">
-      <div className={styles["detail--main"]}>
-        <div className={styles["detail--main--left"]}>{children}</div>
-        <aside className={`${styles["detail--aside"]} no-print`}>
-          <ActionSidebar
-            actions={sidebarActions}
-            onClickAction={onClickAction}
-          />
-        </aside>
-      </div>
-    </article>
-  </div>
-);
+}: DetailPageWrapperProps) => {
+  useEffect(() => window.scrollTo(0, 0), []);
 
+  return (
+    <div className={styles[`detail-wrapper`]}>
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+      </Helmet>
+      <article className={styles.detail} id="resource">
+        <div className={styles["detail--main"]}>
+          <div className={styles["detail--main--left"]}>{children}</div>
+          <aside className={`${styles["detail--aside"]} no-print`}>
+            <ActionSidebar
+              actions={sidebarActions}
+              onClickAction={onClickAction}
+            />
+          </aside>
+        </div>
+      </article>
+    </div>
+  );
+};
 export default DetailPageWrapper;

--- a/app/pages/BrowseResultsPage/BrowseResultsPage.tsx
+++ b/app/pages/BrowseResultsPage/BrowseResultsPage.tsx
@@ -49,11 +49,7 @@ export const BrowseResultsPage = () => {
   const { refine: refinePagination } = usePagination();
   const { refine: clearRefinements } = useClearRefinements();
 
-  const handleFirstResultFocus = useCallback((node: HTMLDivElement | null) => {
-    if (node) {
-      node.focus();
-    }
-  }, []);
+  useEffect(() => window.scrollTo(0, 0), []);
 
   const subcategoryNames = subcategories?.map((c) => c.name);
   const { name: categoryName, sortAlgoliaSubcategoryRefinements } = category;
@@ -141,7 +137,7 @@ export const BrowseResultsPage = () => {
                       <SearchResult
                         hit={hit}
                         key={`${hit.id} - ${hit.name}`}
-                        ref={index === 0 ? handleFirstResultFocus : null}
+                        ref={null}
                       />
                     )
                   )}

--- a/app/pages/EventDetailPage/EventDetailPage.tsx
+++ b/app/pages/EventDetailPage/EventDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect } from "react";
+import React, { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import { useParams } from "react-router-dom";
 import { BlocksRenderer } from "@strapi/blocks-react-renderer";
@@ -20,8 +20,6 @@ type TagRow = { title: string; value: ReactNode[] };
 export const EventDetailPage = () => {
   const { eventListingId } = useParams();
   const { data, error, isLoading } = useEventData(eventListingId as string);
-
-  useEffect(() => window.scrollTo(0, 0), []);
 
   if (error) {
     return (

--- a/app/pages/OrganizationDetailPage.tsx
+++ b/app/pages/OrganizationDetailPage.tsx
@@ -34,7 +34,6 @@ export const OrganizationDetailPage = () => {
   const [error, setError] = useState<Error | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
-  useEffect(() => window.scrollTo(0, 0), []);
   useEffect(() => {
     const fetchOrganizationWithErrorHandling = async () => {
       setIsLoading(true);

--- a/app/pages/SearchResultsPage/SearchResultsPage.tsx
+++ b/app/pages/SearchResultsPage/SearchResultsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import { SearchMapActions } from "components/SearchAndBrowse/SearchResults/SearchResults";
 import Sidebar from "components/SearchAndBrowse/Sidebar/Sidebar";
 import styles from "./SearchResultsPage.module.scss";
@@ -30,6 +30,8 @@ export const SearchResultsPage = () => {
     status,
     indexUiState: { query = null },
   } = useInstantSearch();
+
+  useEffect(() => window.scrollTo(0, 0), []);
 
   const handleFirstResultFocus = useCallback((node: HTMLDivElement | null) => {
     if (node) {

--- a/app/pages/ServiceDetailPage/ServiceDetailPage.tsx
+++ b/app/pages/ServiceDetailPage/ServiceDetailPage.tsx
@@ -59,8 +59,6 @@ export const ServiceDetailPage = () => {
 
   const { pathname } = useLocation();
 
-  useEffect(() => window.scrollTo(0, 0), []);
-
   useEffect(() => {
     const fetchServiceOrFallback = async () => {
       try {


### PR DESCRIPTION
🎫: [When user is scrolled down on page and clicks an internal link, they are still scrolled down on page](https://www.notion.so/exygy/When-user-is-scrolled-down-on-page-and-clicks-an-internal-link-they-are-still-scrolled-down-on-page-1823433f03d080b8b15ce3fc9060ccd5?pvs=4)

This PR:
- adds scrollTo logic on the DetailPageWrapper (and removes it from pages that use this wrapper)
- adds scrollTo logic on browse and search results pages
- removes `handleFirstResultFocus` on browse results page. This should only be focused when user selects filters, which still works