### PR TITLE
above tablet should be same height navbar as desktop

### DIFF
--- a/app/components/ui/Navigation/Navigation.module.scss
+++ b/app/components/ui/Navigation/Navigation.module.scss
@@ -73,9 +73,9 @@
     display: none;
   }
   .primaryRow {
-    height: $header-mobile-height;
+    height: $header-height;
     flex-wrap: nowrap;
-    padding: $spacing-4_5;
+    padding: 0 $spacing-4_5;
     gap: $spacing-8;
 
     :nth-child(2) {


### PR DESCRIPTION
🎫: [Update Our415 Logo](https://www.notion.so/exygy/Update-Our415-Logo-18a3433f03d08081b7c0c92f3065328d?pvs=24)

### 📝 Description
This PR:
- adds new header logo to strapi
- adds new footer logo to project (this is the way it was before, we can create a ticket to add this to strapi if we want)
- updates css to make these logos look good within our existing components (they are different aspect ratio from former logo, used my own discretion on this)

### 🖼 Screenshots

HEADER:

|         | before | after |
| ------- | ------ | ----- |
| desktop |    <img width="350" alt="image" src="https://github.com/user-attachments/assets/3ef7b411-71d6-4e5e-9c74-770187f09143" />   | <img width="350" alt="image" src="https://github.com/user-attachments/assets/afe36436-c78f-4bc4-bfc2-76c62970d191" />|
| mobile  |   Didn't take screenshot     |   <img width="498" alt="image" src="https://github.com/user-attachments/assets/d87f5f45-1e64-4c86-a004-6ef789edd6c6" />|


### ✏️ Notes
