### PR TITLE
[Our415-Bug-57-fix] Fix issue introduced by 

### DIFF
--- a/app/components/SearchAndBrowse/Sidebar/Sidebar.module.scss
+++ b/app/components/SearchAndBrowse/Sidebar/Sidebar.module.scss
@@ -29,6 +29,7 @@
   border-right: 1px solid $border-gray;
   padding: 20px 25px 50px 30px;
   overflow-y: auto;
+  position: sticky;
 
   @media screen and (max-width: $break-desktop-s) {
     height: auto;
@@ -37,6 +38,7 @@
     align-self: flex-start;
     border-right: 0;
     background-color: #fff;
+    position: static;
   }
 
   @media screen and (max-width: $break-tablet-s) {


### PR DESCRIPTION
add on to #311 

Adds `position: sticky` back to .sidebar only on full width screen. Was causing issues where the sidebar was still 100vh but scrolled upward to leave white space at the bottom of the section

Before:
<img width="963" alt="image" src="https://github.com/user-attachments/assets/083eed0c-f3a4-4bcc-af30-0eddd1885443" />

After:
<img width="955" alt="image" src="https://github.com/user-attachments/assets/9e9e3135-5cdb-4d13-86b1-927b453975cf" />

