### PR TITLE
[Our415-T-148] Map marker issues

### DIFF
--- a/app/components/DetailPage/MapOfLocations.tsx
+++ b/app/components/DetailPage/MapOfLocations.tsx
@@ -3,7 +3,7 @@ import GoogleMap from "google-map-react";
 import config from "../../config";
 import { LocationDetails } from "../../models";
 import { useAppContext } from "../../utils";
-import { computeGridOffset } from "utils/map";
+import { computeGridOffset, groupServiceLocations } from "utils/map";
 import {
   createMapOptions,
   CustomMarker,
@@ -30,14 +30,7 @@ export const MapOfLocations = ({
     Number(locations[0].address.longitude),
   ];
 
-  const groupedLocations = locations.reduce((acc, location, i) => {
-    const key = `${location.address.latitude}-${location.address.longitude}`;
-    if (!acc[key]) {
-      acc[key] = [];
-    }
-    acc[key].push({ location, markerIndex: i + 1 });
-    return acc;
-  }, {} as Record<string, { location: LocationDetails; markerIndex: number }[]>);
+  const groupedLocations = groupServiceLocations(locations);
 
   const markers = Object.entries(groupedLocations).flatMap(([, group]) => {
     if (group.length === 1) {

--- a/app/components/DetailPage/MapOfLocations.tsx
+++ b/app/components/DetailPage/MapOfLocations.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import GoogleMap from "google-map-react";
 import config from "../../config";
 import { LocationDetails } from "../../models";
-import LocationTimesAccordion from "./LocationTimesAccordion";
+import { useAppContext } from "../../utils";
+import { computeGridOffset } from "utils/map";
 import {
   createMapOptions,
   CustomMarker,
   UserLocationMarker,
 } from "../ui/MapElements";
-import { useAppContext } from "../../utils";
+import LocationTimesAccordion from "./LocationTimesAccordion";
 import styles from "./MapOfLocations.module.scss";
 
 // TODO: Accordion needs big refactor/rebuild which is out of scope of this ticket. Will create new ticket.

--- a/app/components/DetailPage/MapOfLocations.tsx
+++ b/app/components/DetailPage/MapOfLocations.tsx
@@ -30,6 +30,50 @@ export const MapOfLocations = ({
     Number(locations[0].address.longitude),
   ];
 
+  const groupedLocations = locations.reduce((acc, location, i) => {
+    const key = `${location.address.latitude}-${location.address.longitude}`;
+    if (!acc[key]) {
+      acc[key] = [];
+    }
+    acc[key].push({ location, markerIndex: i + 1 });
+    return acc;
+  }, {} as Record<string, { location: LocationDetails; markerIndex: number }[]>);
+
+  const markers = Object.entries(groupedLocations).flatMap(([, group]) => {
+    if (group.length === 1) {
+      const { location, markerIndex } = group[0];
+      return (
+        <CustomMarker
+          key={location.id}
+          lat={Number(location.address.latitude)}
+          lng={Number(location.address.longitude)}
+          text={`${markerIndex}`}
+        />
+      );
+    } else {
+      const epicenterLat = Number(group[0].location.address.latitude);
+      const epicenterLng = Number(group[0].location.address.longitude);
+
+      const groupMarkers = group.map((item, index) => {
+        const { offsetLat, offsetLng } = computeGridOffset(
+          index,
+          group.length,
+          epicenterLat,
+          epicenterLng
+        );
+        return (
+          <CustomMarker
+            key={`${item.location.id}-${index}`}
+            lat={offsetLat}
+            lng={offsetLng}
+            text={`${item.markerIndex}`}
+          />
+        );
+      });
+      return groupMarkers.reverse();
+    }
+  });
+
   return (
     <div className={styles.locationsMap} data-testid="map-of-locations">
       <div className="map">
@@ -42,14 +86,7 @@ export const MapOfLocations = ({
           options={createMapOptions}
         >
           {inSanFrancisco && <UserLocationMarker lat={userLat} lng={userLng} />}
-          {locations.map(({ address, id }, i) => (
-            <CustomMarker
-              key={id}
-              lat={Number(address?.latitude) || 0}
-              lng={Number(address?.longitude) || 0}
-              text={`${i + 1}`}
-            />
-          ))}
+          {markers}
         </GoogleMap>
       </div>
       <LocationTimesAccordion locations={locations} />

--- a/app/components/DetailPage/MapOfLocations.tsx
+++ b/app/components/DetailPage/MapOfLocations.tsx
@@ -51,8 +51,7 @@ export const MapOfLocations = ({
         const { offsetLat, offsetLng } = computeGridOffset(
           index,
           group.length,
-          epicenterLat,
-          epicenterLng
+          { lat: epicenterLat, lng: epicenterLng }
         );
         return (
           <CustomMarker

--- a/app/components/SearchAndBrowse/SearchMap/SearchMap.tsx
+++ b/app/components/SearchAndBrowse/SearchMap/SearchMap.tsx
@@ -58,10 +58,10 @@ export const SearchMap = ({
     }
   };
 
-  const groupedMarkers = groupHitsByLocation(hits);
+  const groupedHits = groupHitsByLocation(hits);
 
-  const markers = Object.keys(groupedMarkers).flatMap((key) => {
-    const group = groupedMarkers[key];
+  const markers = Object.keys(groupedHits).flatMap((key) => {
+    const group = groupedHits[key];
     const total = group.length;
 
     if (total === 1) {

--- a/app/components/SearchAndBrowse/SearchMap/SearchMap.tsx
+++ b/app/components/SearchAndBrowse/SearchMap/SearchMap.tsx
@@ -34,6 +34,22 @@ const groupHitsByLocation = (hits: TransformedSearchHit[]) => {
   }, {} as Record<string, { hit: TransformedSearchHit; location: { id: string; lat: string; long: string; label: string } }[]>);
 };
 
+const computeGridOffset = (
+  index: number,
+  total: number,
+  epicenterLat: number,
+  epicenterLng: number,
+  spacing: number = 0.00004
+): { offsetLat: number; offsetLng: number } => {
+  const cols = Math.ceil(Math.sqrt(total));
+  const rows = Math.ceil(total / cols);
+  const row = Math.floor(index / cols);
+  const col = index % cols;
+  const offsetLat = epicenterLat + (row - (rows - 1) / 2) * spacing;
+  const offsetLng = epicenterLng + (col - (cols - 1) / 2) * spacing;
+  return { offsetLat, offsetLng };
+};
+
 export const SearchMap = ({
   hits,
   mobileMapIsCollapsed,
@@ -90,15 +106,14 @@ export const SearchMap = ({
     } else {
       const epicenterLat = Number(group[0].location.lat);
       const epicenterLng = Number(group[0].location.long);
-      const cols = Math.ceil(Math.sqrt(total));
-      const rows = Math.ceil(total / cols);
-      const spacing = 0.00004;
 
       const groupMarkers = group.map((item, index) => {
-        const row = Math.floor(index / cols);
-        const col = index % cols;
-        const offsetLat = epicenterLat + (row - (rows - 1) / 2) * spacing;
-        const offsetLng = epicenterLng + (col - (cols - 1) / 2) * spacing;
+        const { offsetLat, offsetLng } = computeGridOffset(
+          index,
+          total,
+          epicenterLat,
+          epicenterLng
+        );
         return (
           <GoogleSearchHitMarkerWorkaround
             key={`${item.location.id}-${index}`}

--- a/app/components/SearchAndBrowse/SearchMap/SearchMap.tsx
+++ b/app/components/SearchAndBrowse/SearchMap/SearchMap.tsx
@@ -80,12 +80,10 @@ export const SearchMap = ({
       const epicenterLng = Number(group[0].location.long);
 
       const groupMarkers = group.map((item, index) => {
-        const { offsetLat, offsetLng } = computeGridOffset(
-          index,
-          total,
-          epicenterLat,
-          epicenterLng
-        );
+        const { offsetLat, offsetLng } = computeGridOffset(index, total, {
+          lat: epicenterLat,
+          lng: epicenterLng,
+        });
         return (
           <GoogleSearchHitMarkerWorkaround
             key={`${item.location.id}-${index}`}

--- a/app/components/SearchAndBrowse/SearchMap/SearchMap.tsx
+++ b/app/components/SearchAndBrowse/SearchMap/SearchMap.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from "react-tippy";
 import "react-tippy/dist/tippy.css";
 import SearchEntry from "components/SearchAndBrowse/SearchMap/SearchEntry";
 import { useAppContext, useAppContextUpdater } from "utils";
+import { groupHitsByLocation, computeGridOffset } from "utils/map";
 import { Button } from "components/ui/inline/Button/Button";
 import {
   createMapOptions,
@@ -20,35 +21,6 @@ interface SearchMapProps {
   mobileMapIsCollapsed: boolean;
   handleSearchMapAction: (searchMapAction: SearchMapActions) => void;
 }
-
-const groupHitsByLocation = (hits: TransformedSearchHit[]) => {
-  return hits.reduce((acc, hit) => {
-    hit.locations.forEach((location) => {
-      const key = `${location.lat}-${location.long}`;
-      if (!acc[key]) {
-        acc[key] = [];
-      }
-      acc[key].push({ hit, location });
-    });
-    return acc;
-  }, {} as Record<string, { hit: TransformedSearchHit; location: { id: string; lat: string; long: string; label: string } }[]>);
-};
-
-const computeGridOffset = (
-  index: number,
-  total: number,
-  epicenterLat: number,
-  epicenterLng: number,
-  spacing: number = 0.00004
-): { offsetLat: number; offsetLng: number } => {
-  const cols = Math.ceil(Math.sqrt(total));
-  const rows = Math.ceil(total / cols);
-  const row = Math.floor(index / cols);
-  const col = index % cols;
-  const offsetLat = epicenterLat + (row - (rows - 1) / 2) * spacing;
-  const offsetLng = epicenterLng + (col - (cols - 1) / 2) * spacing;
-  return { offsetLat, offsetLng };
-};
 
 export const SearchMap = ({
   hits,

--- a/app/utils/map.test.ts
+++ b/app/utils/map.test.ts
@@ -1,0 +1,37 @@
+import { computeGridOffset } from "./map";
+
+describe("computeGridOffset", () => {
+  const epicenter = { lat: 0, lng: 0 };
+  const total = 9;
+
+  it("should return { offsetLat: -0.00004, offsetLng: -0.00004 } for index 0, making the first item visually render in the bottom left", () => {
+    const { offsetLat, offsetLng } = computeGridOffset(0, total, epicenter);
+    expect(offsetLat).toBeCloseTo(-0.00004);
+    expect(offsetLng).toBeCloseTo(-0.00004);
+  });
+
+  it("should return { offsetLat: -0.00004, offsetLng: 0.00004 } for index 2, making the third item visually render in the bottom right corner", () => {
+    const { offsetLat, offsetLng } = computeGridOffset(2, total, epicenter);
+    expect(offsetLat).toBeCloseTo(-0.00004);
+    expect(offsetLng).toBeCloseTo(0.00004);
+  });
+  it("should return { offsetLat: 0, 0 } for index 4, making the fifth item visually render in the middle and be equal to the epicenter's coordinates", () => {
+    const { offsetLat, offsetLng } = computeGridOffset(2, total, epicenter);
+    expect(offsetLat).toBeCloseTo(0);
+    expect(offsetLng).toBeCloseTo(0);
+    expect(offsetLat).toBeCloseTo(epicenter.lat);
+    expect(offsetLng).toBeCloseTo(epicenter.lng);
+  });
+
+  it("should return { offsetLat: 0.00004, offsetLng: -0.00004 } for index 6, making the seventh item visually render in the top left corner", () => {
+    const { offsetLat, offsetLng } = computeGridOffset(2, total, epicenter);
+    expect(offsetLat).toBeCloseTo(0.00004);
+    expect(offsetLng).toBeCloseTo(-0.00004);
+  });
+
+  it("should return { offsetLat: 0.00004, offsetLng: 0.00004 } for index 8, making the last item visually render in the top right corner", () => {
+    const { offsetLat, offsetLng } = computeGridOffset(2, total, epicenter);
+    expect(offsetLat).toBeCloseTo(0.00004);
+    expect(offsetLng).toBeCloseTo(-0.00004);
+  });
+});

--- a/app/utils/map.ts
+++ b/app/utils/map.ts
@@ -1,0 +1,30 @@
+import { TransformedSearchHit } from "models";
+
+export const groupHitsByLocation = (hits: TransformedSearchHit[]) => {
+  return hits.reduce((acc, hit) => {
+    hit.locations.forEach((location) => {
+      const key = `${location.lat}-${location.long}`;
+      if (!acc[key]) {
+        acc[key] = [];
+      }
+      acc[key].push({ hit, location });
+    });
+    return acc;
+  }, {} as Record<string, { hit: TransformedSearchHit; location: { id: string; lat: string; long: string; label: string } }[]>);
+};
+
+export const computeGridOffset = (
+  index: number,
+  total: number,
+  epicenterLat: number,
+  epicenterLng: number,
+  spacing: number = 0.00004
+): { offsetLat: number; offsetLng: number } => {
+  const cols = Math.ceil(Math.sqrt(total));
+  const rows = Math.ceil(total / cols);
+  const row = Math.floor(index / cols);
+  const col = index % cols;
+  const offsetLat = epicenterLat + (row - (rows - 1) / 2) * spacing;
+  const offsetLng = epicenterLng + (col - (cols - 1) / 2) * spacing;
+  return { offsetLat, offsetLng };
+};

--- a/app/utils/map.ts
+++ b/app/utils/map.ts
@@ -26,18 +26,27 @@ export const groupServiceLocations = (locations: LocationDetails[]) => {
   }, {} as Record<string, { location: LocationDetails; markerIndex: number }[]>);
 };
 
+/*
+    Input: Current index, total number of items at a location, and that location's coordinates 
+    Output: A new set of coordinates for the current item as its place on a grid. Meant to be run on multiple values. Items will be evenly spaced apart and the epicenter will be at the direct center of the grid.
+*/
 export const computeGridOffset = (
   index: number,
   total: number,
-  epicenterLat: number,
-  epicenterLng: number,
-  spacing = 0.00004
+  epicenterCoords: {
+    lat: number;
+    lng: number;
+  }
 ): { offsetLat: number; offsetLng: number } => {
+  const SPACING = 0.00004;
   const cols = Math.ceil(Math.sqrt(total));
+  // if not a perfect square, round up as an extra row for the remainder items
   const rows = Math.ceil(total / cols);
+  // determine current item's row and column by its index (it will be the only item at this grid position)
   const row = Math.floor(index / cols);
   const col = index % cols;
-  const offsetLat = epicenterLat + (row - (rows - 1) / 2) * spacing;
-  const offsetLng = epicenterLng + (col - (cols - 1) / 2) * spacing;
+  // create new coordinates based on item's row and column position
+  const offsetLat = epicenterCoords.lat + (row - (rows - 1) / 2) * SPACING;
+  const offsetLng = epicenterCoords.lng + (col - (cols - 1) / 2) * SPACING;
   return { offsetLat, offsetLng };
 };

--- a/app/utils/map.ts
+++ b/app/utils/map.ts
@@ -1,4 +1,6 @@
-import { TransformedSearchHit } from "models";
+import { LocationDetails, TransformedSearchHit } from "models";
+
+//  TODO: Refactor SearchMap so that both maps create markers from a list of locations, not from hits
 
 export const groupHitsByLocation = (hits: TransformedSearchHit[]) => {
   return hits.reduce((acc, hit) => {
@@ -11,6 +13,17 @@ export const groupHitsByLocation = (hits: TransformedSearchHit[]) => {
     });
     return acc;
   }, {} as Record<string, { hit: TransformedSearchHit; location: { id: string; lat: string; long: string; label: string } }[]>);
+};
+
+export const groupServiceLocations = (locations: LocationDetails[]) => {
+  return locations.reduce((acc, location, i) => {
+    const key = `${location.address.latitude}-${location.address.longitude}`;
+    if (!acc[key]) {
+      acc[key] = [];
+    }
+    acc[key].push({ location, markerIndex: i + 1 });
+    return acc;
+  }, {} as Record<string, { location: LocationDetails; markerIndex: number }[]>);
 };
 
 export const computeGridOffset = (

--- a/app/utils/map.ts
+++ b/app/utils/map.ts
@@ -31,7 +31,7 @@ export const computeGridOffset = (
   total: number,
   epicenterLat: number,
   epicenterLng: number,
-  spacing: number = 0.00004
+  spacing = 0.00004
 ): { offsetLat: number; offsetLng: number } => {
   const cols = Math.ceil(Math.sqrt(total));
   const rows = Math.ceil(total / cols);


### PR DESCRIPTION
### 📝 Description
🎫: [Map marker issues](https://www.notion.so/exygy/Map-marker-issues-1973433f03d080d3b39cf118bc077701?pvs=24)

Fixes the issues of multiple services at the same location's markers being stacked on top of each other

Changes:
- Adds an algorithm to create a grid layout of the markers, where the epicenter is the service's location
- reverses the order of markers so that, before if there were 10 markers (1-10) at the same location, the user would see 10 on top, now they see 1 on top

NOTE: Unfortunately I had to recreate the same logic with slight variations for both SearchMap and MapOfLocations. They're different enough that shared helpers won't work without some significant refactoring, which is not a priority ahead of Feb 22 

### 🖼 Screenshots

|         | before | after |
| ------- | ------ | ----- |
| zoomed out |   <img width="350" alt="image" src="https://github.com/user-attachments/assets/3d499e1a-3c1b-453a-9205-ea5d80b59949" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/f4136055-d129-4093-9f2c-38e12487271b" />   |
| zoomed in  |  <img width="350" alt="image" src="https://github.com/user-attachments/assets/f3608ef1-c06d-4f5a-80df-0c92f7cc5268" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/e3458243-28f9-413e-9ef1-57cdc5a271e4" /> |

### ✏️ Notes
