### PR TITLE
[OUR415-BUG-35] sign up link change

### DIFF
--- a/app/components/EmailSignup/Emailsignup.tsx
+++ b/app/components/EmailSignup/Emailsignup.tsx
@@ -10,7 +10,7 @@ export const EmailSignup = () => (
     <h2>Join our mailing list to get updates</h2>
     <Button
       isExternalLink={false}
-      href="javascript:void( window.open( 'https://dcyf.jotform.com/242708128943966', 'blank', 'scrollbars=yes, toolbar=no, width=700, height=500' ) ) "
+      href="javascript:void( window.open( 'https://forms.office.com/g/vns6t1Y5uJ', 'blank', 'scrollbars=yes, toolbar=no, width=700, height=1000' ) ) "
     >
       Sign up today
     </Button>


### PR DESCRIPTION
### 📝 Description
🎫: [Wrong link to the sign up survey](https://www.notion.so/exygy/Wrong-link-to-the-sign-up-survey-1823433f03d0806d92a7c0bd97681595?pvs=4)

This PR:
- Adds new signup form link
- Makes the popup window a little longer to accommodate all fields / buttons

### 🖼 Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop |   <img width="350" alt="image" src="https://github.com/user-attachments/assets/7e877884-f426-4a04-a6c3-493e7e892e8e" /> |    <img width="350" alt="Screenshot 2025-02-17 at 11 26 27 AM" src="https://github.com/user-attachments/assets/ea364309-9d0d-4e52-92c8-059cdf680aa4" />|





### ✏️ Notes
