### PR TITLE
Remove gap between navbar and navigation on tablet sized screens

### DIFF
--- a/app/components/ui/Navigation/MobileNavigation.module.scss
+++ b/app/components/ui/Navigation/MobileNavigation.module.scss
@@ -148,9 +148,6 @@
     display: flex;
     align-items: center;
   }
-  .mobileNavigationContainer {
-    top: $header-mobile-height;
-  }
 }
 
 // Less than tablet


### PR DESCRIPTION
Before:
<img width="459" alt="image" src="https://github.com/user-attachments/assets/fac25768-e8ae-4c02-91dd-fdaec3146c63" />


After:
<img width="445" alt="image" src="https://github.com/user-attachments/assets/a57bc272-bc0b-4eab-8e7b-e7b9afd11cba" />
