### PR TITLE
add anchor ids to services and events sections on homepage

### DIFF
--- a/app/components/ui/inline/Button/Button.tsx
+++ b/app/components/ui/inline/Button/Button.tsx
@@ -93,7 +93,7 @@ export const Button = ({
 
   // Links that follow same visual guidelines as buttons
   if (href) {
-    const isExternal = isExternalLink ?? !href?.startsWith("/");
+    const isExternal = isExternalLink ?? !/^[\/#]/.test(href);
 
     const linkProps = isExternal && { target: "_blank", rel: "noreferrer" };
 

--- a/app/pages/HomePage/HomePage.tsx
+++ b/app/pages/HomePage/HomePage.tsx
@@ -36,15 +36,20 @@ export const HomePage = () => {
           buttons={hero.buttons}
         />
       )}
-      <CategorySection />
+      <span id="browse-services">
+        <CategorySection />
+      </span>
+
       {eventsData && (
-        <HomePageSection
-          title={"Featured events"}
-          description={""}
-          backgroundColor={"tertiary"}
-        >
-          <EventCardSection events={eventsData} />
-        </HomePageSection>
+        <span id="featured-events">
+          <HomePageSection
+            title={"Featured events"}
+            description={""}
+            backgroundColor={"tertiary"}
+          >
+            <EventCardSection events={eventsData} />
+          </HomePageSection>
+        </span>
       )}
 
       {two_column_content_block?.map((content) => (


### PR DESCRIPTION
Per Kyle and Nick's request.

Adds ids to the Browse Services and Featured Events sections so the Homepage CTA can link to them