### PR TITLE
Rm heroku deploy gh actions

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -34,13 +34,3 @@ jobs:
           ALGOLIA_READ_ONLY_API_KEY: ${{ secrets.ALGOLIA_READ_ONLY_API_KEY }}
           STRAPI_API_TOKEN: ${{ secrets.STRAPI_API_TOKEN }}
           STRAPI_API_URL: ${{ secrets.STRAPI_API_URL }}
-      - name: Build, Push and Release a Docker container to Heroku.
-        uses: gonuit/heroku-docker-deploy@v1.3.3
-        with:
-          email: ${{ secrets.HEROKU_EMAIL }}
-          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-          heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
-          dockerfile_directory: ./
-          dockerfile_name: Dockerfile
-          docker_options: "--no-cache"
-          process_type: web


### PR DESCRIPTION
This PR removes the deploy github actions to see if we can rely on the connection set in heroku instead. Hoping this will fix our broken auto-deploy.