### PR TITLE
Strapi Fix - Remove Bearer token

### DIFF
--- a/app/hooks/StrapiAPI.ts
+++ b/app/hooks/StrapiAPI.ts
@@ -91,10 +91,7 @@ export function useHomePageEventsData() {
 
   const dataFetcher = () =>
     fetcher<{ data: Array<StrapiDatumResponse<EventResponse>> }>(
-      `${config.STRAPI_API_URL}/api/${path}`,
-      {
-        Authorization: `Bearer ${config.STRAPI_API_TOKEN}`,
-      }
+      `${config.STRAPI_API_URL}/api/${path}`
     );
 
   const { data, error, isLoading } = useSWR(`/api/${path}`, dataFetcher) as {


### PR DESCRIPTION
I think we don't need our admin API token as our Bearer JWT token. Testing this on staging.